### PR TITLE
Refresh documentation to match the current v1.4 API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,6 @@
 # Schema
 
-**Version:** 1.3.2
-
-A powerful .NET library for defining, managing, and manipulating document schemas with a visual editor. This library provides a comprehensive type system for creating strongly-typed data structures that can be serialized, validated, and code-generated.
+A .NET library for defining, managing, and editing data structure schemas with a rich type system, type-safe identifiers, and polymorphic JSON serialization.
 
 ## Overview
 
@@ -10,10 +8,9 @@ The Schema library enables developers to:
 
 -   **Define Data Structures**: Create classes, enums, and complex types using a schema definition system
 -   **Visual Editing**: Use the included SchemaEditor for graphical schema design
--   **Type Safety**: Leverage strong string types and compile-time type checking
--   **Code Generation**: Generate code from schema definitions
+-   **Type Safety**: Leverage semantic string types and compile-time type checking
 -   **Serialization**: Save and load schemas as JSON with full type information
--   **Data Sources**: Manage multiple data sources within a single schema
+-   **Data Sources**: Declare which data files are bound to which schema classes
 
 ## Key Features
 
@@ -21,7 +18,7 @@ The Schema library enables developers to:
 
 -   Define classes with typed members
 -   Create enumerations with named values
--   Support for primitive types (int, float, string, bool, etc.)
+-   Support for primitive types (int, long, float, double, string, bool, etc.)
 -   Complex types including arrays, objects, and containers
 -   Vector types (Vector2, Vector3, Vector4) and color types (RGB, RGBA)
 
@@ -30,36 +27,35 @@ The Schema library enables developers to:
 -   ImGui-based desktop application for schema editing
 -   Tree-based navigation of schema elements
 -   Interactive property editing
--   Real-time schema validation
 
 ### 🔧 **Type System**
 
--   Strong string types for compile-time safety
+-   Semantic string types for compile-time safety
 -   Polymorphic type system with JSON serialization support
--   Built-in and custom type support
 -   Container types with keying support
-
-### 📊 **Data Management**
-
--   Multiple data source support
--   Project-relative path management
--   Safe file operations with backup/recovery
 
 ## Quick Start
 
 ```csharp
-// Load an existing schema
-if (Schema.TryLoad("path/to/schema.json".As<AbsoluteFilePath>(), out Schema? schema))
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+// Create a schema and add a class
+Schema schema = new();
+SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+userClass?.AddMember("Name".As<MemberName>())?.SetType(new SchemaTypes.String());
+userClass?.AddMember("Age".As<MemberName>())?.SetType(new SchemaTypes.Int());
+
+// Serialize to JSON and save
+string json = SchemaSerializer.Serialize(schema);
+File.WriteAllText("user.schema.json", json);
+
+// Load it back (Reassociate() is called automatically)
+if (SchemaSerializer.TryDeserialize(File.ReadAllText("user.schema.json"), out Schema? loaded))
 {
-    // Add a new class
-    var userClass = schema.AddClass("User".As<ClassName>());
-
-    // Add members to the class
-    var nameMember = userClass?.AddMember("Name".As<MemberName>());
-    var ageMember = userClass?.AddMember("Age".As<MemberName>());
-
-    // Save the schema
-    schema.Save();
+    Console.WriteLine($"Loaded {loaded!.Classes.Count} classes");
 }
 ```
 
@@ -67,26 +63,26 @@ if (Schema.TryLoad("path/to/schema.json".As<AbsoluteFilePath>(), out Schema? sch
 
 -   **[Schema](api/schema-core.md)** - Core library containing the schema definition system
 -   **[SchemaEditor](features/schema-editor.md)** - Visual editor application
--   **[Schema.Test](development/testing.md)** - Test suite for the library
+-   **Schema.Test** - MSTest suite for the library (see the [development guide](development/README.md))
 
 ## Documentation
 
 -   **[Getting Started](getting-started.md)** - Setup and basic usage
--   **[API Reference](api/)** - Detailed API documentation
--   **[Features](features/)** - In-depth feature guides
--   **[Examples](examples/)** - Code examples and tutorials
--   **[Development](development/)** - Contributing and development setup
+-   **[API Reference](api/README.md)** - Detailed API documentation
+-   **[Features](features/README.md)** - In-depth feature guides
+-   **[Examples](examples/README.md)** - Code examples and tutorials
+-   **[Development](development/README.md)** - Contributing and development setup
+-   **[Roadmap](ROADMAP.md)** - Current state and planned work
 
 ## Dependencies
 
 This project uses the ktsu.dev ecosystem of libraries:
 
--   `ktsu.StrongPaths` - Type-safe file and directory path handling
--   `ktsu.StrongStrings` - Strong string type system
--   `ktsu.ToStringJsonConverter` - JSON serialization utilities
--   `ktsu.ImGuiApp` - ImGui application framework (SchemaEditor)
--   `ktsu.ImGuiPopups` - ImGui popup utilities (SchemaEditor)
--   `ktsu.ImGuiWidgets` - ImGui widget library (SchemaEditor)
+-   `ktsu.Semantics.Strings` - Type-safe semantic string wrappers
+-   `ktsu.Semantics.Paths` - Type-safe file and directory path handling
+-   `ktsu.RoundTripStringJsonConverter` - JSON serialization for semantic strings
+-   `ktsu.ImGui.App` / `ktsu.ImGui.Widgets` / `ktsu.ImGui.Popups` - ImGui application framework (SchemaEditor)
+-   `ktsu.AppDataStorage` - Persistent settings storage (SchemaEditor)
 
 ## License
 
@@ -94,4 +90,4 @@ Licensed under the MIT License. See [LICENSE.md](../LICENSE.md) for details.
 
 ## Contributing
 
-Contributions are welcome! Please see the [development guide](development/contributing.md) for details on how to contribute to this project.
+Contributions are welcome! Please see the [development guide](development/README.md) for details on how to contribute to this project.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,115 +1,75 @@
 # API Reference
 
-This section contains detailed API documentation for all public classes, interfaces, and types in the Schema library.
+This section contains API documentation for the public types in the Schema library. All public types carry XML documentation comments in source, which IDEs surface directly; this section covers the core entry points.
 
 ## Core API
 
 ### [Schema Class](schema-core.md)
 
-The main schema container class that manages classes, enums, data sources, and code generators.
-
-### [Schema Types](schema-types.md)
-
-Complete reference for all available types in the schema system, including primitives, vectors, and complex types.
-
-### [Strong String Types](strong-strings.md)
-
-Type-safe string types used throughout the library for compile-time safety.
-
-## Schema Elements
-
-### [Schema Class](schema-class.md)
-
-User-defined classes that contain typed members representing data structures.
-
-### [Schema Member](schema-member.md)
-
-Properties within schema classes that have specific types and behaviors.
-
-### [Schema Enum](schema-enum.md)
-
-Enumeration types with named values for representing discrete choices.
-
-### [Schema Child](schema-child.md)
-
-Base class for all schema elements that can be contained within a schema.
-
-## Data Management
-
-### [Data Source](data-source.md)
-
-Configuration for data sources that provide data for schema instances.
-
-### [Schema Paths](schema-paths.md)
-
-Path management utilities for handling relative and absolute paths within schemas.
-
-## Collections
-
-### [Schema Child Collection](schema-child-collection.md)
-
-Collection management utilities for working with schema children.
-
-## Code Generation
-
-### [Schema Code Generator](schema-code-generator.md)
-
-Configuration and utilities for generating code from schema definitions.
+The main schema container class that manages classes, enums, data sources, and code generators, plus the `SchemaSerializer` used to persist schemas to JSON.
 
 ## Quick Reference
 
 ### Key Classes
 
-| Class          | Purpose                                   |
-| -------------- | ----------------------------------------- |
-| `Schema`       | Main container for all schema definitions |
-| `SchemaClass`  | User-defined class with typed members     |
-| `SchemaMember` | Property within a schema class            |
-| `SchemaEnum`   | Enumeration with named values             |
-| `DataSource`   | Data source configuration                 |
+| Class                 | Purpose                                       |
+| --------------------- | --------------------------------------------- |
+| `Schema`              | Main container for all schema definitions     |
+| `SchemaClass`         | User-defined class with typed members         |
+| `SchemaMember`        | Property within a schema class                |
+| `SchemaEnum`          | Enumeration with named values                 |
+| `DataSource`          | Binds a data file to a schema class           |
+| `SchemaCodeGenerator` | Declares a code generation output             |
+| `SchemaSerializer`    | JSON serialization for `Schema` objects       |
 
 ### Key Types
+
+All types live in the `ktsu.Schema.Models.Types` namespace and derive from `BaseType`:
 
 | Type                   | Description                 |
 | ---------------------- | --------------------------- |
 | `SchemaTypes.BaseType` | Abstract base for all types |
-| `SchemaTypes.Int`      | Integer type                |
+| `SchemaTypes.Int`      | 32-bit integer type         |
+| `SchemaTypes.Long`     | 64-bit integer type         |
+| `SchemaTypes.Float`    | Single-precision type       |
+| `SchemaTypes.Double`   | Double-precision type       |
 | `SchemaTypes.String`   | String type                 |
+| `SchemaTypes.Bool`     | Boolean type                |
+| `SchemaTypes.DateTime` | Date/time type              |
+| `SchemaTypes.TimeSpan` | Duration type               |
 | `SchemaTypes.Array`    | Array/collection type       |
 | `SchemaTypes.Object`   | Reference to a schema class |
 | `SchemaTypes.Enum`     | Reference to a schema enum  |
+| `SchemaTypes.None`     | Unset/placeholder type      |
 
-### Strong String Types
+Vector (`Vector2`, `Vector3`, `Vector4`) and color (`ColorRGB`, `ColorRGBA`) types are also available.
 
-| Type             | Purpose                  |
-| ---------------- | ------------------------ |
-| `ClassName`      | Names of schema classes  |
-| `MemberName`     | Names of class members   |
-| `EnumName`       | Names of enumerations    |
-| `EnumValueName`  | Names of enum values     |
-| `DataSourceName` | Names of data sources    |
-| `ContainerName`  | Names of container types |
+### Semantic String Types
 
-## Navigation
+Identifiers use semantic string wrappers from `ktsu.Semantics.Strings` (namespace `ktsu.Schema.Models.Names`); convert with `"value".As<T>()`:
 
--   **[Getting Started](../getting-started.md)** - Basic usage and setup
--   **[Features](../features/)** - Feature guides and tutorials
--   **[Examples](../examples/)** - Code examples and patterns
--   **[Development](../development/)** - Contributing and development
+| Type                | Purpose                  |
+| ------------------- | ------------------------ |
+| `ClassName`         | Names of schema classes  |
+| `MemberName`        | Names of class members   |
+| `EnumName`          | Names of enumerations    |
+| `EnumValueName`     | Names of enum values     |
+| `BaseTypeName`      | Names of types           |
+| `ContainerName`     | Names of container types |
+| `DataSourceName`    | Names of data sources    |
+| `CodeGeneratorName` | Names of code generators |
 
 ## API Conventions
 
 ### Naming
 
--   Classes use PascalCase: `SchemaClass`, `SchemaMember`
--   Methods use PascalCase: `AddClass()`, `TryGetMember()`
--   Properties use PascalCase: `Name`, `Members`
--   Strong string types end with their type: `ClassName`, `MemberName`
+-   Classes, methods, and properties use PascalCase: `SchemaClass`, `AddClass()`, `Members`
+-   Semantic string types end with their kind: `ClassName`, `MemberName`
 
 ### Error Handling
 
 -   Methods that can fail use the `Try...` pattern returning `bool`
--   Methods that throw exceptions are documented with possible exception types
+-   `Add...` methods return `null` when an element with the same name already exists
 -   Null checking is enforced through nullable reference types
 
 ### Thread Safety
@@ -119,6 +79,13 @@ Configuration and utilities for generating code from schema definitions.
 
 ### JSON Serialization
 
--   All schema objects support JSON serialization using `System.Text.Json`
--   Custom converters handle strong string types and polymorphic types
--   Serialized schemas maintain full type information
+-   Use `SchemaSerializer.Serialize()` / `SchemaSerializer.TryDeserialize()`
+-   camelCase property names with a `TypeName` polymorphic discriminator
+-   `TryDeserialize()` calls `Reassociate()` automatically
+
+## Navigation
+
+-   **[Getting Started](../getting-started.md)** - Basic usage and setup
+-   **[Features](../features/README.md)** - Feature guides and tutorials
+-   **[Examples](../examples/README.md)** - Code examples and patterns
+-   **[Development](../development/README.md)** - Contributing and development

--- a/docs/api/schema-core.md
+++ b/docs/api/schema-core.md
@@ -1,55 +1,21 @@
 # Schema Class
 
-**Namespace:** `ktsu.Schema`  
-**Assembly:** Schema.dll
+**Namespace:** `ktsu.Schema.Models`
+**Assembly:** ktsu.Schema.dll
 
 The main schema container class that manages classes, enums, data sources, and code generators.
 
 ## Declaration
 
 ```csharp
-public partial class Schema
+public class Schema
 ```
 
 ## Overview
 
-The `Schema` class is the root container for all schema definitions. It provides methods for loading, saving, and manipulating schema elements including classes, enums, data sources, and code generators. Each schema can be serialized to and from JSON while maintaining full type information.
+The `Schema` class is the root container for all schema definitions. It provides methods for adding, querying, and removing schema elements including classes, enums, data sources, and code generators. Schemas are serialized to and from JSON with the companion `SchemaSerializer` class while maintaining full type information.
 
 ## Properties
-
-### File Paths
-
-#### FilePath
-
-```csharp
-[JsonIgnore] public AbsoluteFilePath FilePath { get; private set; }
-```
-
-Gets the absolute file path of the schema.
-
-#### RelativePaths
-
-```csharp
-[JsonInclude] public SchemaPaths RelativePaths { get; private set; }
-```
-
-Gets the relative paths associated with the schema.
-
-#### ProjectRootPath
-
-```csharp
-[JsonIgnore] public AbsoluteDirectoryPath ProjectRootPath { get; }
-```
-
-Gets the project root path based on the file path and relative project root path.
-
-#### DataSourcePath
-
-```csharp
-[JsonIgnore] public AbsoluteDirectoryPath DataSourcePath { get; }
-```
-
-Gets the data source path based on the file path and relative data source path.
 
 ### Collections
 
@@ -87,14 +53,6 @@ Gets the read-only collection of code generators.
 
 ### Utility Properties
 
-#### FileExtension
-
-```csharp
-[JsonIgnore] public static FileExtension FileExtension { get; }
-```
-
-Gets the file extension for schema files (`.schema.json`).
-
 #### FirstClass
 
 ```csharp
@@ -113,57 +71,15 @@ Gets the last class in the schema, or null if no classes exist.
 
 ## Methods
 
-### Loading and Saving
+### Association
 
-#### TryLoad
-
-```csharp
-public static bool TryLoad(AbsoluteFilePath filePath, out Schema? schema)
-```
-
-Tries to load a schema from the specified file path.
-
-**Parameters:**
-
--   `filePath`: The file path to load the schema from
--   `schema`: The loaded schema, or null if loading failed
-
-**Returns:** `true` if the schema was successfully loaded; otherwise, `false`.
-
-**Example:**
+#### Reassociate
 
 ```csharp
-if (Schema.TryLoad("myschema.schema.json".As<AbsoluteFilePath>(), out Schema? schema))
-{
-    Console.WriteLine($"Loaded schema with {schema.Classes.Count} classes");
-}
+public void Reassociate()
 ```
 
-#### Save
-
-```csharp
-public void Save()
-```
-
-Saves the schema to its file path. Uses atomic file operations with backup and recovery.
-
-**Example:**
-
-```csharp
-schema.Save(); // Saves to the current FilePath
-```
-
-#### ChangeFilePath
-
-```csharp
-public void ChangeFilePath(AbsoluteFilePath newFilePath)
-```
-
-Changes the file path of the schema.
-
-**Parameters:**
-
--   `newFilePath`: The new file path
+Re-establishes parent-child relationships between the schema and its elements. Call this after deserializing a schema manually; `SchemaSerializer.TryDeserialize()` calls it for you.
 
 ### Managing Classes
 
@@ -175,10 +91,6 @@ public SchemaClass? AddClass(ClassName name)
 
 Adds a new class with the specified name.
 
-**Parameters:**
-
--   `name`: The name of the class to add
-
 **Returns:** The added schema class, or null if a class with that name already exists.
 
 #### AddClass (from Type)
@@ -187,13 +99,7 @@ Adds a new class with the specified name.
 public SchemaClass? AddClass(Type type)
 ```
 
-Adds a new class based on a .NET Type, automatically creating members for public properties.
-
-**Parameters:**
-
--   `type`: The .NET type to create a schema class from
-
-**Returns:** The added schema class, or null if failed.
+Adds a new class based on a .NET Type, automatically creating members for public properties and fields. Referenced classes and enums are added to the schema recursively.
 
 #### TryAddClass
 
@@ -204,191 +110,136 @@ public bool TryAddClass(Type type)
 
 Tries to add a class without returning the instance.
 
-#### GetClass
+#### GetClass / TryGetClass
 
 ```csharp
 public SchemaClass? GetClass(ClassName name)
+public bool TryGetClass(ClassName name, out SchemaClass? schemaClass)
 ```
 
 Gets a class by name.
 
-**Parameters:**
-
--   `name`: The name of the class to retrieve
-
-**Returns:** The schema class, or null if not found.
-
-#### TryGetClass
-
-```csharp
-public bool TryGetClass(ClassName name, out SchemaClass? schemaClass)
-```
-
-Tries to get a class by name.
-
-**Parameters:**
-
--   `name`: The name of the class to retrieve
--   `schemaClass`: The retrieved schema class, if found
-
-**Returns:** `true` if the class was found; otherwise, `false`.
-
 ### Managing Enums
-
-#### AddEnum
 
 ```csharp
 public SchemaEnum? AddEnum(EnumName name)
-```
-
-Adds a new enum with the specified name.
-
-#### TryAddEnum
-
-```csharp
 public bool TryAddEnum(EnumName name)
-```
-
-Tries to add an enum without returning the instance.
-
-#### GetEnum
-
-```csharp
 public SchemaEnum? GetEnum(EnumName name)
-```
-
-Gets an enum by name.
-
-#### TryGetEnum
-
-```csharp
 public bool TryGetEnum(EnumName name, out SchemaEnum? schemaEnum)
 ```
 
-Tries to get an enum by name.
+Adds or retrieves enums by name, following the same conventions as classes.
 
 ### Managing Data Sources
 
-#### AddDataSource
-
 ```csharp
 public DataSource? AddDataSource(DataSourceName name)
-```
-
-Adds a new data source with the specified name.
-
-#### TryAddDataSource
-
-```csharp
 public bool TryAddDataSource(DataSourceName name)
+public DataSource? GetDataSource(DataSourceName name)
+public bool TryGetDataSource(DataSourceName name, out DataSource? dataSource)
 ```
 
-Tries to add a data source without returning the instance.
+Adds or retrieves data sources by name.
 
-#### GetDataSource
+### Managing Code Generators
 
 ```csharp
-public DataSource? GetDataSource(DataSourceName name)
+public SchemaCodeGenerator? AddCodeGenerator(CodeGeneratorName name)
+public bool TryAddCodeGenerator(CodeGeneratorName name)
+public SchemaCodeGenerator? GetCodeGenerator(CodeGeneratorName name)
+public bool TryGetCodeGenerator(CodeGeneratorName name, out SchemaCodeGenerator? codeGenerator)
 ```
 
-Gets a data source by name.
+Adds or retrieves code generators by name.
 
 ### Type System
 
 #### GetTypes
 
 ```csharp
-public IEnumerable<SchemaTypes.BaseType> GetTypes()
+public IEnumerable<BaseType> GetTypes()
 ```
 
-Gets all available types in the schema, including built-in types and user-defined classes/enums.
+Gets the distinct types currently used by members across the schema.
 
-**Returns:** An enumerable of all available types.
+## SchemaSerializer
 
-### Utility Methods
-
-#### EnsureDirectoryExists
+**Namespace:** `ktsu.Schema.Models`
 
 ```csharp
-public static void EnsureDirectoryExists(string path)
+public static class SchemaSerializer
 ```
 
-Ensures that the directory for the specified path exists.
+Provides JSON serialization for `Schema` objects using `System.Text.Json` with camelCase property names and a `TypeName` polymorphic discriminator.
 
-**Parameters:**
-
--   `path`: The path to ensure the directory exists for
-
-## Static Properties
-
-### JsonSerializerOptions
+#### Serialize
 
 ```csharp
-internal static JsonSerializerOptions JsonSerializerOptions { get; }
+public static string Serialize(Schema schema)
 ```
 
-Gets the JSON serializer options used for schema serialization. Configured with:
+Serializes a schema to an indented JSON string.
 
--   Indented writing
--   Include fields
--   Strong string type converters
--   Enum string conversion
--   Polymorphic type support
+#### TryDeserialize
+
+```csharp
+public static bool TryDeserialize(string json, out Schema? schema)
+```
+
+Tries to deserialize a JSON string to a schema, calling `Reassociate()` automatically on success.
+
+**Returns:** `true` if deserialization succeeded; otherwise, `false`.
 
 ## Usage Examples
 
 ### Creating a Complete Schema
 
 ```csharp
-using ktsu.Schema;
-using ktsu.StrongPaths;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+using SchemaTypes = ktsu.Schema.Models.Types;
 
 // Create new schema
-var schema = new Schema();
-schema.ChangeFilePath("game.schema.json".As<AbsoluteFilePath>());
+Schema schema = new();
 
 // Add enums
-var difficultyEnum = schema.AddEnum("Difficulty".As<EnumName>());
-difficultyEnum?.AddValue("Easy".As<EnumValueName>());
-difficultyEnum?.AddValue("Normal".As<EnumValueName>());
-difficultyEnum?.AddValue("Hard".As<EnumValueName>());
+SchemaEnum? difficultyEnum = schema.AddEnum("Difficulty".As<EnumName>());
+difficultyEnum?.TryAddValue("Easy".As<EnumValueName>());
+difficultyEnum?.TryAddValue("Normal".As<EnumValueName>());
+difficultyEnum?.TryAddValue("Hard".As<EnumValueName>());
 
-// Add classes
-var playerClass = schema.AddClass("Player".As<ClassName>());
-var nameMember = playerClass?.AddMember("Name".As<MemberName>());
-var levelMember = playerClass?.AddMember("Level".As<MemberName>());
-var difficultyMember = playerClass?.AddMember("Difficulty".As<MemberName>());
-
-// Set types
-if (nameMember != null)
-    nameMember.Type = new SchemaTypes.String();
-if (levelMember != null)
-    levelMember.Type = new SchemaTypes.Int();
-if (difficultyMember != null)
-    difficultyMember.Type = new SchemaTypes.Enum { EnumName = "Difficulty".As<EnumName>() };
+// Add classes and members with types
+SchemaClass? playerClass = schema.AddClass("Player".As<ClassName>());
+playerClass?.AddMember("Name".As<MemberName>())?.SetType(new SchemaTypes.String());
+playerClass?.AddMember("Level".As<MemberName>())?.SetType(new SchemaTypes.Int());
+playerClass?.AddMember("Difficulty".As<MemberName>())?.SetType(
+    new SchemaTypes.Enum { EnumName = "Difficulty".As<EnumName>() });
 
 // Add data source
-var playersDataSource = schema.AddDataSource("Players".As<DataSourceName>());
+DataSource? playersDataSource = schema.AddDataSource("Players".As<DataSourceName>());
 if (playersDataSource != null)
 {
     playersDataSource.File = "players.json".As<RelativeFilePath>();
-    playersDataSource.Class = playerClass;
+    playersDataSource.ClassName = "Player".As<ClassName>();
 }
 
 // Save schema
-schema.Save();
+File.WriteAllText("game.schema.json", SchemaSerializer.Serialize(schema));
 ```
 
 ### Loading and Querying a Schema
 
 ```csharp
-if (Schema.TryLoad("game.schema.json".As<AbsoluteFilePath>(), out Schema? schema))
+string json = File.ReadAllText("game.schema.json");
+if (SchemaSerializer.TryDeserialize(json, out Schema? schema) && schema is not null)
 {
     // List all classes
-    foreach (var schemaClass in schema.Classes)
+    foreach (SchemaClass schemaClass in schema.Classes)
     {
         Console.WriteLine($"Class: {schemaClass.Name}");
-        foreach (var member in schemaClass.Members)
+        foreach (SchemaMember member in schemaClass.Members)
         {
             Console.WriteLine($"  {member.Name}: {member.Type.DisplayName}");
         }
@@ -397,12 +248,12 @@ if (Schema.TryLoad("game.schema.json".As<AbsoluteFilePath>(), out Schema? schema
     // Get specific class
     if (schema.TryGetClass("Player".As<ClassName>(), out SchemaClass? playerClass))
     {
-        Console.WriteLine($"Player class has {playerClass.Members.Count} members");
+        Console.WriteLine($"Player class has {playerClass!.Members.Count} members");
     }
 
-    // List available types
-    var availableTypes = schema.GetTypes().ToList();
-    Console.WriteLine($"Available types: {string.Join(", ", availableTypes.Select(t => t.DisplayName))}");
+    // List the types in use
+    List<SchemaTypes.BaseType> usedTypes = schema.GetTypes().ToList();
+    Console.WriteLine($"Types in use: {string.Join(", ", usedTypes.Select(t => t.DisplayName))}");
 }
 ```
 
@@ -412,7 +263,6 @@ The `Schema` class is not thread-safe. If you need to access a schema from multi
 
 ## See Also
 
--   [SchemaClass](schema-class.md) - Individual classes within a schema
--   [SchemaEnum](schema-enum.md) - Enumerations within a schema
--   [DataSource](data-source.md) - Data source configuration
--   [SchemaTypes](schema-types.md) - Available type system
+-   [API Reference](README.md) - Quick reference for all public types
+-   [Getting Started](../getting-started.md) - Basic usage walkthrough
+-   [Basic Schema Example](../examples/basic-schema.md) - Complete worked example

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -2,86 +2,25 @@
 
 This section contains information for developers who want to contribute to the Schema library or extend it for their own use.
 
-## Getting Started
-
-### [Setup and Building](setup.md)
-
-How to set up your development environment and build the project from source.
-
-### [Project Structure](project-structure.md)
-
-Overview of the codebase organization and key components.
-
-### [Contributing](contributing.md)
-
-Guidelines for contributing code, documentation, and examples.
-
-## Development Topics
-
-### [Testing](testing.md)
-
-How to run tests, write new tests, and ensure code quality.
-
-### [Code Style](code-style.md)
-
-Coding standards, formatting, and best practices used in the project.
+## Guides
 
 ### [Architecture](architecture.md)
 
 High-level architecture overview and design decisions.
 
-### [Performance](performance.md)
+### [Roadmap](../ROADMAP.md)
 
-Performance considerations and optimization techniques.
+Current state of the project and planned work.
 
-## Extension and Customization
+## Development Environment
 
-### [Custom Types](custom-types.md)
+| Component | Requirement                                          |
+| --------- | ---------------------------------------------------- |
+| .NET SDK  | 10.0 (see `global.json`; the library multi-targets net7.0–net10.0) |
+| IDE       | Visual Studio 2022 or VS Code                        |
+| Git       | Latest version                                       |
 
-How to create and integrate custom types into the schema system.
-
-### [Plugins](plugins.md)
-
-Creating plugins and extensions for the Schema Editor.
-
-### [Code Generation Templates](code-generation.md)
-
-Developing custom code generation templates and targets.
-
-### [Serialization Customization](serialization.md)
-
-Customizing JSON serialization behavior for special requirements.
-
-## Maintenance
-
-### [Release Process](release-process.md)
-
-How releases are created and versioned.
-
-### [Security](security.md)
-
-Security considerations and vulnerability reporting.
-
-### [Dependencies](dependencies.md)
-
-Managing dependencies and keeping them up to date.
-
-### [Documentation](documentation.md)
-
-How to update and maintain project documentation.
-
-## Quick Reference
-
-### Development Environment
-
-| Component  | Requirement                   |
-| ---------- | ----------------------------- |
-| .NET SDK   | 8.0 or 9.0                    |
-| IDE        | Visual Studio 2022 or VS Code |
-| Git        | Latest version                |
-| PowerShell | 7.0+ (Windows)                |
-
-### Build Commands
+## Build Commands
 
 ```bash
 # Restore dependencies
@@ -93,170 +32,64 @@ dotnet build
 # Run tests
 dotnet test
 
-# Build SchemaEditor
-dotnet build SchemaEditor/SchemaEditor.csproj
+# Run a specific test
+dotnet test --filter "FullyQualifiedName~TestName"
 
-# Package for release
-dotnet pack --configuration Release
+# Launch the visual editor
+dotnet run --project SchemaEditor
 ```
 
-### Project Structure Overview
-
-```
-Schema/
-├── Schema/                  # Core library
-├── Schema.Test/            # Unit tests
-├── SchemaEditor/          # Visual editor application
-├── docs/                  # Documentation
-├── scripts/               # Build and utility scripts
-└── examples/              # Example projects
-```
-
-### Key Directories
+## Project Structure
 
 | Directory       | Purpose                        |
 | --------------- | ------------------------------ |
 | `Schema/`       | Core schema definition library |
-| `Schema.Test/`  | Unit and integration tests     |
+| `Schema.Test/`  | MSTest unit tests              |
 | `SchemaEditor/` | ImGui-based visual editor      |
 | `docs/`         | Markdown documentation         |
-| `scripts/`      | Build automation and utilities |
+| `scripts/`      | Build automation (PSBuild)     |
 
-## Getting Help
+Within the core library:
 
-### For Contributors
+-   `Schema/Models/` - `Schema`, `SchemaClass`, `SchemaEnum`, `SchemaMember`, `DataSource`, `SchemaCodeGenerator`, and `SchemaSerializer`
+-   `Schema/Models/Types/` - The polymorphic type system (`BaseType` and derived types)
+-   `Schema/Models/Names/` - Semantic string name types
+-   `Schema/Contracts/` - Interfaces describing the schema object model
 
--   **Issues**: Report bugs or request features on GitHub
--   **Discussions**: Join conversations about development topics
--   **Code Review**: Get feedback on pull requests
--   **Mentoring**: Connect with maintainers for guidance
+## Testing
 
-### For Extension Developers
+Tests live in `Schema.Test` and use MSTest with the Microsoft.Testing.Platform runner. Run them with `dotnet test`. All new features should include tests; the existing suites (`SchemaTests`, `SchemaClassTests`, `SchemaEnumTests`, `TypeSystemTests`, `SchemaSerializerTests`, `AddClassFromTypeTests`) show the conventions in use.
 
--   **API Documentation**: [API Reference](../api/) for extending the library
--   **Architecture Guide**: [Architecture](architecture.md) for understanding internals
--   **Custom Types**: [Custom Types](custom-types.md) for type system extensions
--   **Examples**: [Examples](../examples/) for implementation patterns
+## Code Style
 
-## Development Workflow
+Code style is enforced at build time by the analyzers configured through `ktsu.Sdk` and the repository `.editorconfig` (tabs for indentation in C#, file-scoped namespaces, XML documentation on public APIs). Run a local build before submitting changes — style violations fail the build.
 
-### Standard Workflow
+```bash
+# Verify formatting and analyzers
+dotnet build
+
+# Auto-fix formatting
+dotnet format
+```
+
+## Contributing Workflow
 
 1. **Fork** the repository
 2. **Clone** your fork locally
 3. **Create** a feature branch
-4. **Make** your changes
-5. **Test** your changes thoroughly
+4. **Make** your changes, including tests
+5. **Build and test** (`dotnet build && dotnet test`)
 6. **Submit** a pull request
 
-### Detailed Steps
+Contributions are welcome in all areas: the core library, the editor, documentation, tests, and examples. Contributors are listed in [AUTHORS.md](../../AUTHORS.md).
 
-```bash
-# Clone your fork
-git clone https://github.com/yourusername/Schema.git
-cd Schema
+## Releases
 
-# Create feature branch
-git checkout -b feature/my-new-feature
-
-# Make changes and commit
-git add .
-git commit -m "Add new feature"
-
-# Push to your fork
-git push origin feature/my-new-feature
-
-# Create pull request via GitHub web interface
-```
-
-### Code Quality Checks
-
-Before submitting changes:
-
-```bash
-# Run all tests
-dotnet test
-
-# Check code formatting
-dotnet format --verify-no-changes
-
-# Run static analysis
-dotnet build --verbosity normal
-
-# Build documentation
-# (Follow docs/development/documentation.md)
-```
-
-## Development Best Practices
-
-### Code Quality
-
--   **Write Tests**: All new features should include tests
--   **Follow Standards**: Use consistent coding style and patterns
--   **Document Changes**: Update documentation for public APIs
--   **Performance**: Consider performance impact of changes
-
-### Git Practices
-
--   **Small Commits**: Make focused, atomic commits
--   **Clear Messages**: Write descriptive commit messages
--   **Feature Branches**: Use branches for new features
--   **Clean History**: Rebase and squash when appropriate
-
-### Testing Practices
-
--   **Unit Tests**: Test individual components in isolation
--   **Integration Tests**: Test component interactions
--   **End-to-End Tests**: Test complete workflows
--   **Performance Tests**: Benchmark critical paths
-
-## Release Information
-
-### Current Version: 1.3.2
-
--   **Stability**: Production ready
--   **API Status**: Stable with semantic versioning
--   **Breaking Changes**: Documented in CHANGELOG.md
--   **Support**: Active development and maintenance
-
-### Version History
-
-| Version | Release Date | Key Features                                |
-| ------- | ------------ | ------------------------------------------- |
-| 1.3.2   | Current      | Enhanced type system, editor improvements   |
-| 1.3.1   | Previous     | Bug fixes and performance improvements      |
-| 1.3.0   | Previous     | Major feature release with new capabilities |
-
-### Compatibility
-
--   **.NET**: 8.0 and 9.0 supported
--   **Platforms**: Windows, macOS, Linux
--   **Dependencies**: ktsu.dev ecosystem libraries
--   **Breaking Changes**: Follow semantic versioning
-
-## Community
-
-### Contributing Areas
-
-We welcome contributions in these areas:
-
--   **Core Library**: Schema definition and type system improvements
--   **Editor**: Visual editor features and usability enhancements
--   **Documentation**: Guides, examples, and API documentation
--   **Testing**: Test coverage and quality improvements
--   **Performance**: Optimization and benchmarking
--   **Examples**: Real-world usage examples and tutorials
-
-### Getting Recognition
-
--   **Contributors**: Listed in AUTHORS.md
--   **Major Features**: Highlighted in release notes
--   **Documentation**: Credited in relevant sections
--   **Community**: Featured in project discussions
+Releases are automated through the GitHub Actions workflow (`.github/workflows/dotnet.yml`) using the PSBuild pipeline in `scripts/`. Versioning is derived from commit history (`[major]`/`[minor]` markers in commit messages; patch otherwise), the changelog is generated automatically, and packages publish to NuGet. Breaking changes follow semantic versioning and are documented in [CHANGELOG.md](../../CHANGELOG.md).
 
 ## See Also
 
 -   **[Getting Started](../getting-started.md)** - Using the library
--   **[API Reference](../api/)** - Detailed API documentation
--   **[Features](../features/)** - Feature guides and capabilities
--   **[Examples](../examples/)** - Usage examples and tutorials
+-   **[API Reference](../api/README.md)** - Detailed API documentation
+-   **[Features](../features/README.md)** - Feature guides and capabilities
+-   **[Examples](../examples/README.md)** - Usage examples and tutorials

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,205 +1,16 @@
 # Examples
 
-This section provides practical examples and tutorials for common use cases with the Schema library.
+This section contains practical examples demonstrating how to use the Schema library for common scenarios.
 
-## Quick Start Examples
+## Available Examples
 
 ### [Basic Schema Creation](basic-schema.md)
 
-Learn how to create your first schema with classes, members, and enums.
+Create a complete schema from scratch with classes, members, enums, and data sources, then serialize it to a `.schema.json` file.
 
-### [Loading and Saving](loading-saving.md)
+### [Dependency Injection](dependency-injection.md)
 
-Examples of loading existing schemas and saving changes safely.
-
-### [Working with Types](working-with-types.md)
-
-How to use different types including primitives, arrays, and custom objects.
-
-## Real-World Use Cases
-
-### [Game Data Management](game-data.md)
-
-Complete example of managing game data including players, levels, and configuration.
-
-### [Configuration System](configuration-system.md)
-
-Build a type-safe configuration system for applications.
-
-### [API Data Models](api-data-models.md)
-
-Define API request/response models and validation schemas.
-
-### [Document Schema](document-schema.md)
-
-Create schemas for structured documents and content management.
-
-## Advanced Examples
-
-### [Complex Relationships](complex-relationships.md)
-
-Handle complex object relationships and circular references.
-
-### [Collections and Arrays](collections-examples.md)
-
-Work with arrays, maps, and keyed collections effectively.
-
-### [Code Generation](code-generation-examples.md)
-
-Generate C# classes, TypeScript interfaces, and other code from schemas.
-
-### [Schema Migration](migration-examples.md)
-
-Handle schema evolution and data migration scenarios.
-
-## Integration Examples
-
-### [ASP.NET Core Integration](aspnet-integration.md)
-
-Integrate schemas with ASP.NET Core applications for API validation.
-
-### [Entity Framework Integration](ef-integration.md)
-
-Use schemas to define Entity Framework models and database schemas.
-
-### [JSON Schema Export](json-schema-examples.md)
-
-Export schemas to JSON Schema format for API documentation.
-
-### [Validation Examples](validation-examples.md)
-
-Implement custom validation rules and error handling.
-
-## Editor Examples
-
-### [Schema Editor Workflows](editor-workflows.md)
-
-Common workflows and best practices for using the visual editor.
-
-### [Import/Export Examples](import-export.md)
-
-Examples of importing from various sources and exporting to different formats.
-
-## Performance Examples
-
-### [Large Schema Management](large-schemas.md)
-
-Techniques for working with large, complex schemas efficiently.
-
-### [Memory Optimization](memory-optimization.md)
-
-Optimize memory usage when working with many schema instances.
-
-## Quick Reference
-
-### Example Categories
-
-| Category        | Use Case              | Examples                                                                             |
-| --------------- | --------------------- | ------------------------------------------------------------------------------------ |
-| **Basics**      | Learning fundamentals | [Basic Schema](basic-schema.md), [Types](working-with-types.md)                      |
-| **Real-World**  | Production scenarios  | [Game Data](game-data.md), [APIs](api-data-models.md)                                |
-| **Advanced**    | Complex features      | [Relationships](complex-relationships.md), [Generation](code-generation-examples.md) |
-| **Integration** | Framework integration | [ASP.NET](aspnet-integration.md), [EF](ef-integration.md)                            |
-| **Performance** | Optimization          | [Large Schemas](large-schemas.md), [Memory](memory-optimization.md)                  |
-
-### By Complexity Level
-
-#### 🟢 **Beginner**
-
--   [Basic Schema Creation](basic-schema.md)
--   [Loading and Saving](loading-saving.md)
--   [Working with Types](working-with-types.md)
--   [Editor Workflows](editor-workflows.md)
-
-#### 🟡 **Intermediate**
-
--   [Game Data Management](game-data.md)
--   [Configuration System](configuration-system.md)
--   [Collections and Arrays](collections-examples.md)
--   [Import/Export](import-export.md)
-
-#### 🔴 **Advanced**
-
--   [Complex Relationships](complex-relationships.md)
--   [Code Generation](code-generation-examples.md)
--   [Schema Migration](migration-examples.md)
--   [Large Schema Management](large-schemas.md)
-
-### By Feature
-
-| Feature               | Examples                                                                         |
-| --------------------- | -------------------------------------------------------------------------------- |
-| **Classes & Members** | [Basic Schema](basic-schema.md), [Game Data](game-data.md)                       |
-| **Enums**             | [Basic Schema](basic-schema.md), [Configuration](configuration-system.md)        |
-| **Arrays**            | [Collections](collections-examples.md), [API Models](api-data-models.md)         |
-| **Data Sources**      | [Game Data](game-data.md), [Documents](document-schema.md)                       |
-| **Code Generation**   | [Code Generation](code-generation-examples.md), [ASP.NET](aspnet-integration.md) |
-| **Validation**        | [Validation](validation-examples.md), [API Models](api-data-models.md)           |
-
-## Getting Started with Examples
-
-### For New Users
-
-1. Start with [Basic Schema Creation](basic-schema.md)
-2. Try [Loading and Saving](loading-saving.md)
-3. Explore [Working with Types](working-with-types.md)
-4. Practice with [Editor Workflows](editor-workflows.md)
-
-### For Specific Use Cases
-
--   **Game Development**: [Game Data Management](game-data.md)
--   **Web APIs**: [API Data Models](api-data-models.md)
--   **Configuration**: [Configuration System](configuration-system.md)
--   **Documents**: [Document Schema](document-schema.md)
-
-### For Advanced Features
-
--   **Code Generation**: [Code Generation Examples](code-generation-examples.md)
--   **Large Systems**: [Large Schema Management](large-schemas.md)
--   **Integration**: [ASP.NET Core](aspnet-integration.md)
-
-## Example Projects
-
-### Sample Applications
-
-Each example includes a complete, runnable project demonstrating the concepts:
-
-```
-examples/
-├── BasicSchema/          # Simple schema creation
-├── GameData/            # Game data management
-├── ConfigSystem/        # Application configuration
-├── ApiModels/           # REST API models
-├── DocumentSchema/      # Document management
-└── Integration/         # Framework integrations
-    ├── AspNetCore/      # ASP.NET Core example
-    └── EntityFramework/ # EF Core example
-```
-
-### Running Examples
-
-1. Clone the repository
-2. Navigate to an example directory
-3. Run `dotnet restore` to install dependencies
-4. Run `dotnet run` to execute the example
-5. Follow the README in each example directory
-
-## Contributing Examples
-
-We welcome contributions of new examples! See the [contributing guide](../development/contributing.md) for details on:
-
--   Example structure and format
--   Documentation requirements
--   Code quality standards
--   Testing expectations
-
-### Suggesting Examples
-
-If you have ideas for examples that would be helpful:
-
-1. Open an issue with the "example-request" label
-2. Describe the use case and target audience
-3. Provide any relevant context or requirements
+Register and consume schemas through a dependency injection container.
 
 ## Common Patterns
 
@@ -207,28 +18,26 @@ If you have ideas for examples that would be helpful:
 
 ```csharp
 // 1. Create schema
-var schema = new Schema();
+Schema schema = new();
 
 // 2. Add classes and enums
-var myClass = schema.AddClass("MyClass".As<ClassName>());
+SchemaClass? myClass = schema.AddClass("MyClass".As<ClassName>());
 
-// 3. Add members
-var member = myClass?.AddMember("Property".As<MemberName>());
+// 3. Add members and set types
+myClass?.AddMember("Property".As<MemberName>())?.SetType(new SchemaTypes.String());
 
-// 4. Set types
-member.Type = new SchemaTypes.String();
-
-// 5. Save
-schema.Save();
+// 4. Serialize and save
+File.WriteAllText("my.schema.json", SchemaSerializer.Serialize(schema));
 ```
 
 ### Loading Pattern
 
 ```csharp
-if (Schema.TryLoad(filePath, out Schema? schema))
+string json = File.ReadAllText("my.schema.json");
+if (SchemaSerializer.TryDeserialize(json, out Schema? schema) && schema is not null)
 {
     // Work with loaded schema
-    foreach (var schemaClass in schema.Classes)
+    foreach (SchemaClass schemaClass in schema.Classes)
     {
         // Process classes
     }
@@ -240,16 +49,30 @@ if (Schema.TryLoad(filePath, out Schema? schema))
 ```csharp
 if (schema.TryGetClass("User".As<ClassName>(), out SchemaClass? userClass))
 {
-    if (userClass.TryGetMember("Name".As<MemberName>(), out SchemaMember? nameMember))
+    if (userClass!.TryGetMember("Name".As<MemberName>(), out SchemaMember? nameMember))
     {
         // Work with member
     }
 }
 ```
 
+### Creating Schemas from .NET Types
+
+```csharp
+// Generate a schema class (and any referenced classes/enums) via reflection
+schema.AddClass(typeof(MyExistingClass));
+```
+
+## Suggesting Examples
+
+If you have ideas for examples that would be helpful:
+
+1. Open an issue describing the use case and target audience
+2. Provide any relevant context or requirements
+
 ## Navigation
 
 -   **[Getting Started](../getting-started.md)** - Basic setup and concepts
--   **[API Reference](../api/)** - Detailed API documentation
--   **[Features](../features/)** - Feature guides and tutorials
--   **[Development](../development/)** - Contributing and development setup
+-   **[API Reference](../api/README.md)** - Detailed API documentation
+-   **[Features](../features/README.md)** - Feature guides and tutorials
+-   **[Development](../development/README.md)** - Contributing and development setup

--- a/docs/examples/dependency-injection.md
+++ b/docs/examples/dependency-injection.md
@@ -1,12 +1,6 @@
----
-title: Dependency Injection with SchemaProvider
-description: How to use SchemaProvider in a dependency injection container
-status: draft
----
+# Dependency Injection
 
-# Dependency Injection with SchemaProvider
-
-The Schema library has been refactored to focus solely on schema definition, removing serialization and filesystem concerns. This makes it ideal for dependency injection scenarios.
+The Schema library focuses solely on schema definition — serialization is handled by the separate `SchemaSerializer` class and there are no filesystem concerns baked into the model. This makes it straightforward to use in dependency injection scenarios.
 
 ## Basic Setup
 
@@ -15,220 +9,113 @@ The Schema library has been refactored to focus solely on schema definition, rem
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using ktsu.Schema;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
 
-// Configure services
 var builder = Host.CreateApplicationBuilder(args);
 
-// Register SchemaProvider as a singleton
-builder.Services.AddSingleton<ISchemaProvider, SchemaProvider>();
-
-// Or register a pre-configured schema provider
-builder.Services.AddSingleton<ISchemaProvider>(provider =>
+// Register a pre-configured schema as a singleton
+builder.Services.AddSingleton<Schema>(provider =>
 {
-    var schemaProvider = new SchemaProvider();
-    
-    // Pre-configure with some schema definitions
-    schemaProvider.AddClass((ClassName)"User");
-    schemaProvider.AddEnum((EnumName)"Role");
-    
-    return schemaProvider;
+    Schema schema = new();
+    schema.AddClass("User".As<ClassName>());
+    schema.AddEnum("Role".As<EnumName>());
+    return schema;
 });
 
 var host = builder.Build();
 ```
 
-### Using the SchemaProvider
+### Loading a Schema from a File
 
 ```csharp
+builder.Services.AddSingleton<Schema>(provider =>
+{
+    string json = File.ReadAllText("app.schema.json");
+    return SchemaSerializer.TryDeserialize(json, out Schema? schema) && schema is not null
+        ? schema
+        : throw new InvalidOperationException("Failed to load app.schema.json");
+});
+```
+
+## Consuming the Schema
+
+```csharp
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+using SchemaTypes = ktsu.Schema.Models.Types;
+
 public class MyService
 {
-    private readonly ISchemaProvider _schemaProvider;
-    
-    public MyService(ISchemaProvider schemaProvider)
+    private readonly Schema _schema;
+
+    public MyService(Schema schema)
     {
-        _schemaProvider = schemaProvider;
+        _schema = schema;
     }
-    
+
     public void DefineUserSchema()
     {
-        // Add a User class to the schema
-        var userClass = _schemaProvider.AddClass((ClassName)"User");
+        SchemaClass? userClass = _schema.AddClass("User".As<ClassName>());
         if (userClass != null)
         {
-            // Add members to the User class
-            var nameProperty = userClass.AddMember((MemberName)"Name");
-            nameProperty?.SetType(new SchemaTypes.String());
-            
-            var ageProperty = userClass.AddMember((MemberName)"Age");
-            ageProperty?.SetType(new SchemaTypes.Integer());
-        }
-        
-        // Add an enum for user roles
-        var roleEnum = _schemaProvider.AddEnum((EnumName)"UserRole");
-        if (roleEnum != null)
-        {
-            roleEnum.TryAddValue((EnumValueName)"Admin");
-            roleEnum.TryAddValue((EnumValueName)"User");
-            roleEnum.TryAddValue((EnumValueName)"Guest");
+            userClass.AddMember("Name".As<MemberName>())?.SetType(new SchemaTypes.String());
+            userClass.AddMember("Email".As<MemberName>())?.SetType(new SchemaTypes.String());
         }
     }
-    
-    public void QuerySchema()
+
+    public void DescribeSchema()
     {
-        // Get all classes
-        foreach (var schemaClass in _schemaProvider.Classes)
+        foreach (SchemaClass schemaClass in _schema.Classes)
         {
-            Console.WriteLine($"Class: {schemaClass.Name}");
-            foreach (var member in schemaClass.Members)
-            {
-                Console.WriteLine($"  {member.Name}: {member.Type}");
-            }
-        }
-        
-        // Get all enums
-        foreach (var schemaEnum in _schemaProvider.Enums)
-        {
-            Console.WriteLine($"Enum: {schemaEnum.Name}");
-            foreach (var value in schemaEnum.Values)
-            {
-                Console.WriteLine($"  {value}");
-            }
+            Console.WriteLine($"{schemaClass.Name} ({schemaClass.Members.Count} members)");
         }
     }
 }
 ```
 
-### Adding Schemas from .NET Types
+## Wrapping the Schema in Your Own Abstraction
+
+If your application needs schema management behavior (loading, saving, caching, change tracking), wrap `Schema` in your own service interface so the rest of your code depends on your abstraction rather than the library type:
 
 ```csharp
-public class UserDto
+public interface ISchemaService
 {
-    public string Name { get; set; } = string.Empty;
-    public int Age { get; set; }
-    public UserRole Role { get; set; }
+    Schema Current { get; }
+    void Save();
 }
 
-public enum UserRole
+public class FileSchemaService : ISchemaService
 {
-    Admin,
-    User,
-    Guest
+    private readonly string _path;
+
+    public FileSchemaService(string path)
+    {
+        _path = path;
+        string json = File.ReadAllText(path);
+        Current = SchemaSerializer.TryDeserialize(json, out Schema? schema) && schema is not null
+            ? schema
+            : new Schema();
+    }
+
+    public Schema Current { get; }
+
+    public void Save() => File.WriteAllText(_path, SchemaSerializer.Serialize(Current));
 }
 
-public class SchemaService
-{
-    private readonly ISchemaProvider _schemaProvider;
-    
-    public SchemaService(ISchemaProvider schemaProvider)
-    {
-        _schemaProvider = schemaProvider;
-    }
-    
-    public void RegisterTypes()
-    {
-        // Automatically create schema from .NET types
-        _schemaProvider.AddClass(typeof(UserDto));
-        
-        // The enum will be automatically added when processing UserDto
-        // But you can also add it explicitly:
-        // _schemaProvider.AddClass(typeof(UserRole));
-    }
-}
+// Registration
+builder.Services.AddSingleton<ISchemaService>(_ => new FileSchemaService("app.schema.json"));
 ```
 
-## Separation of Concerns
+## Notes
 
-The refactored SchemaProvider focuses solely on:
+-   `Schema` is not thread-safe; if multiple services mutate a shared schema concurrently, provide your own synchronization.
+-   Register schemas as singletons when they represent application-wide definitions; use factories or scoped services if each scope needs an independent copy.
 
-- **Schema Definition**: Defining classes, enums, and their relationships
-- **Schema Querying**: Retrieving schema information
-- **Type Management**: Managing schema types and their metadata
+## Navigation
 
-It does **NOT** handle:
-
-- **Serialization**: Use separate libraries like System.Text.Json, Newtonsoft.Json, etc.
-- **File I/O**: Use separate services for loading/saving schema definitions
-- **Validation**: Use separate validation libraries
-- **Code Generation**: Use separate code generation tools
-
-## Integration with Other Services
-
-```csharp
-// Separate service for serialization
-public class SchemaSerializationService
-{
-    private readonly ISchemaProvider _schemaProvider;
-    private readonly IJsonSerializer _jsonSerializer;
-    
-    public SchemaSerializationService(
-        ISchemaProvider schemaProvider, 
-        IJsonSerializer jsonSerializer)
-    {
-        _schemaProvider = schemaProvider;
-        _jsonSerializer = jsonSerializer;
-    }
-    
-    public string SerializeSchema()
-    {
-        // Use your preferred serialization library
-        return _jsonSerializer.Serialize(_schemaProvider);
-    }
-}
-
-// Separate service for file operations
-public class SchemaFileService
-{
-    private readonly ISchemaProvider _schemaProvider;
-    private readonly IFileService _fileService;
-    
-    public SchemaFileService(
-        ISchemaProvider schemaProvider,
-        IFileService fileService)
-    {
-        _schemaProvider = schemaProvider;
-        _fileService = fileService;
-    }
-    
-    public async Task SaveSchemaAsync(string filePath)
-    {
-        var serializedSchema = SerializeSchema();
-        await _fileService.WriteAllTextAsync(filePath, serializedSchema);
-    }
-    
-    private string SerializeSchema()
-    {
-        // Implement your serialization logic here
-        return System.Text.Json.JsonSerializer.Serialize(_schemaProvider);
-    }
-}
-```
-
-## Benefits of This Approach
-
-1. **Single Responsibility**: SchemaProvider only handles schema definition
-2. **Testability**: Easy to mock and unit test
-3. **Flexibility**: Use any serialization or file system library you prefer
-4. **Dependency Injection**: Works seamlessly with DI containers
-5. **Separation of Concerns**: Clean architecture with clearly defined responsibilities
-
-## Migration from Legacy Schema Class
-
-If you're migrating from the legacy `Schema` class:
-
-```csharp
-// Old approach (deprecated)
-[Obsolete]
-var schema = new Schema();
-schema.AddClass((ClassName)"User");
-
-// New approach (recommended)
-ISchemaProvider schemaProvider = new SchemaProvider();
-schemaProvider.AddClass((ClassName)"User");
-
-// Or via DI
-public MyService(ISchemaProvider schemaProvider)
-{
-    _schemaProvider = schemaProvider;
-}
-``` 
+-   **[Examples](README.md)** - All examples
+-   **[Basic Schema Creation](basic-schema.md)** - Building a schema from scratch
+-   **[API Reference](../api/schema-core.md)** - Schema and SchemaSerializer details

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,170 +1,50 @@
 # Features Guide
 
-This section covers the key features and capabilities of the Schema library with detailed guides and examples.
+This section covers the key features and capabilities of the Schema library.
 
-## Core Features
-
-### [Schema Definition System](schema-definition.md)
-
-Learn how to define classes, enums, and complex data structures using the schema system.
-
-### [Type System](type-system.md)
-
-Comprehensive guide to the type system including primitives, vectors, arrays, and custom types.
+## Feature Guides
 
 ### [Schema Editor](schema-editor.md)
 
 Visual editor application for creating and modifying schemas with a graphical interface.
 
-### [Strong String Types](strong-strings.md)
+## Feature Overview
 
-Understanding and using the strong string type system for compile-time safety.
+### Schema Definition
 
-## Data Management
+Define classes with typed members and enumerations with named values programmatically through the `Schema` class. See [Getting Started](../getting-started.md) for a walkthrough and the [API Reference](../api/schema-core.md) for details.
 
-### [Data Sources](data-sources.md)
+### Type System
 
-Configure and manage data sources that provide data for your schema definitions.
+A polymorphic type system covering:
 
-### [File Operations](file-operations.md)
+-   **Numeric**: `Int`, `Long`, `Float`, `Double`
+-   **Text and logic**: `String`, `Bool`
+-   **Temporal**: `DateTime`, `TimeSpan`
+-   **Vectors and colors**: `Vector2`, `Vector3`, `Vector4`, `ColorRGB`, `ColorRGBA`
+-   **Complex**: `Array` (with container and key configuration), `Object` (class references), `Enum` (enum references)
 
-Safe file loading, saving, and path management within schemas.
+Types expose classification properties like `IsPrimitive`, `IsNumeric`, `IsIntegral`, `IsDecimal`, `IsArray`, `IsObject`, `IsContainer`, and `IsBuiltIn`.
 
-### [Serialization](serialization.md)
+### Semantic String Types
 
-JSON serialization and deserialization of schemas with full type information.
+All identifiers use type-safe semantic string wrappers (`ClassName`, `MemberName`, `EnumName`, ...) to prevent mixing up different kinds of names at compile time. Convert with `"value".As<T>()`.
 
-## Advanced Features
+### Serialization
 
-### [Code Generation](code-generation.md)
+Schemas serialize to `.schema.json` files via `SchemaSerializer` using `System.Text.Json`, with camelCase property names and a `TypeName` polymorphic discriminator. Deserialization re-establishes parent-child relationships automatically.
 
-Generate code from schema definitions for various target languages and frameworks.
+### Data Sources
 
-### [Collections and Arrays](collections-arrays.md)
+`DataSource` elements declare which data files are bound to which schema classes, so tooling can discover and process the data belonging to a schema.
 
-Working with arrays, containers, and keyed collections in schemas.
+### Code Generators
 
-### [Schema Validation](validation.md)
-
-Validate schema definitions and ensure data integrity.
-
-### [Custom Types](custom-types.md)
-
-Create and integrate custom types into the schema system.
-
-## Integration
-
-### [.NET Integration](dotnet-integration.md)
-
-Integrate schemas with existing .NET applications and frameworks.
-
-### [JSON Schema Export](json-schema-export.md)
-
-Export schemas to standard JSON Schema format for interoperability.
-
-### [Migration and Versioning](migration-versioning.md)
-
-Handle schema migrations and versioning in evolving applications.
-
-## Best Practices
-
-### [Schema Design Patterns](design-patterns.md)
-
-Common patterns and best practices for designing effective schemas.
-
-### [Performance Considerations](performance.md)
-
-Tips for optimizing schema performance in large applications.
-
-### [Error Handling](error-handling.md)
-
-Proper error handling techniques when working with schemas.
-
-### [Testing Schemas](testing.md)
-
-Strategies for testing schema definitions and generated code.
-
-## Quick Reference
-
-### Common Use Cases
-
-| Use Case           | Feature             | Documentation                             |
-| ------------------ | ------------------- | ----------------------------------------- |
-| Define data models | Schema Definition   | [Schema Definition](schema-definition.md) |
-| Visual editing     | Schema Editor       | [Schema Editor](schema-editor.md)         |
-| Type safety        | Strong Strings      | [Strong Strings](strong-strings.md)       |
-| Data storage       | Data Sources        | [Data Sources](data-sources.md)           |
-| Code generation    | Code Generators     | [Code Generation](code-generation.md)     |
-| Collections        | Arrays & Containers | [Collections](collections-arrays.md)      |
-
-### Feature Matrix
-
-| Feature           | Core Library | Schema Editor | Code Generation |
-| ----------------- | :----------: | :-----------: | :-------------: |
-| Schema Definition |      ✅      |      ✅       |       ✅        |
-| Visual Editing    |      ❌      |      ✅       |       ❌        |
-| Type System       |      ✅      |      ✅       |       ✅        |
-| Serialization     |      ✅      |      ✅       |       ✅        |
-| Validation        |      ✅      |      ✅       |       ✅        |
-| Custom Types      |      ✅      |      ⚠️       |       ✅        |
-
-_Legend: ✅ Full Support, ⚠️ Partial Support, ❌ Not Supported_
-
-## Getting Started with Features
-
-### For Beginners
-
-1. Start with [Schema Definition](schema-definition.md) to understand the basics
-2. Try the [Schema Editor](schema-editor.md) for visual editing
-3. Learn about [Data Sources](data-sources.md) for data management
-
-### For Advanced Users
-
-1. Explore [Code Generation](code-generation.md) for automation
-2. Learn [Custom Types](custom-types.md) for extensibility
-3. Review [Performance](performance.md) for optimization
-
-### For Integration
-
-1. Check [.NET Integration](dotnet-integration.md) for existing applications
-2. Review [Migration](migration-versioning.md) for evolving schemas
-3. Study [Best Practices](design-patterns.md) for maintainable designs
-
-## Feature Roadmap
-
-### Current Version (1.3.2)
-
--   ✅ Core schema definition system
--   ✅ Visual schema editor
--   ✅ Strong string types
--   ✅ JSON serialization
--   ✅ Basic code generation
-
-### Planned Features
-
--   🚧 Enhanced code generation templates
--   🚧 Schema migration tools
--   🚧 Plugin system for custom types
--   🚧 Web-based schema editor
--   🚧 Schema validation rules
-
-### Future Considerations
-
--   💭 Multi-language code generation
--   💭 Schema diff and merge tools
--   💭 Real-time collaboration
--   💭 Version control integration
-
-## Community and Support
-
--   **Issues**: Report bugs and feature requests on the project repository
--   **Discussions**: Join community discussions about features and use cases
--   **Examples**: Check the [examples](../examples/) section for real-world usage
--   **Contributing**: See [development](../development/) for contributing to features
+`SchemaCodeGenerator` elements declare code generation outputs for a schema. The generation engine itself is planned work — see the [roadmap](../ROADMAP.md).
 
 ## Navigation
 
 -   **[Getting Started](../getting-started.md)** - Basic setup and usage
--   **[API Reference](../api/)** - Detailed API documentation
--   **[Examples](../examples/)** - Code examples and tutorials
--   **[Development](../development/)** - Contributing and development setup
+-   **[API Reference](../api/README.md)** - Detailed API documentation
+-   **[Examples](../examples/README.md)** - Code examples and tutorials
+-   **[Roadmap](../ROADMAP.md)** - Current state and planned features


### PR DESCRIPTION
## Summary

Phase 1 docs item from the roadmap (#33). The `docs/` tree had rotted badly:

- `docs/README.md`, `docs/api/schema-core.md`, and `docs/examples/README.md` documented APIs removed in v1.4 (`Schema.TryLoad`, `schema.Save()`, `ChangeFilePath`, `EnsureDirectoryExists`, `member.Type =` setter) and outdated dependencies (`ktsu.StrongPaths`/`StrongStrings`/`ToStringJsonConverter`).
- `docs/examples/dependency-injection.md` was written entirely against the removed `SchemaProvider`/`ISchemaProvider`.
- The four section indexes (`api/`, `features/`, `examples/`, `development/README.md`) were aspirational tables of contents linking to **~80 pages that were never written**, plus stale version/compatibility claims (v1.3.2, .NET 8/9).

## Changes

- Rewrote `docs/README.md`, `docs/api/README.md`, `docs/api/schema-core.md`, `docs/features/README.md`, `docs/examples/README.md`, `docs/examples/dependency-injection.md`, and `docs/development/README.md` against the current `Schema` + `SchemaSerializer` API (the root `README.md` was used as the reference for accuracy).
- Slimmed the indexes to link only pages that exist; removed claims of features that don't exist yet (code generation engine, validation, backup/recovery file ops) and pointed those at the roadmap instead.
- Left `getting-started.md`, `examples/basic-schema.md`, `features/schema-editor.md`, and `development/architecture.md` in place — they were verified accurate.
- Net **-764 lines**; every relative `.md` link in `docs/` now resolves (verified with a link check).

**Stacked on #33** (the docs link to `docs/ROADMAP.md`); this PR will retarget to `main` automatically when #33 merges. Docs-only — no code changes, CI paths-ignore applies.

https://claude.ai/code/session_013t3vjk44Yzgt11MAucT4tN

---
_Generated by [Claude Code](https://claude.ai/code/session_013t3vjk44Yzgt11MAucT4tN)_