### PR TITLE
Fix empty member type picker showing only "None"

### DIFF
--- a/Schema.Test/SchemaTests.cs
+++ b/Schema.Test/SchemaTests.cs
@@ -175,6 +175,62 @@ public class SchemaTests
 	}
 
 	[TestMethod]
+	public void TestGetAvailableTypesIncludesBuiltInTypesForEmptySchema()
+	{
+		Schema schemaProvider = new();
+
+		List<SchemaTypes.BaseType> types = [.. schemaProvider.GetAvailableTypes()];
+
+		// An empty schema should still offer every built-in type to pick from, not just None.
+		Assert.IsTrue(types.Any(t => t is SchemaTypes.None), "GetAvailableTypes should include None");
+		Assert.IsTrue(types.Any(t => t is SchemaTypes.Int), "GetAvailableTypes should include Int");
+		Assert.IsTrue(types.Any(t => t is SchemaTypes.String), "GetAvailableTypes should include String");
+		Assert.IsTrue(types.Any(t => t is SchemaTypes.Bool), "GetAvailableTypes should include Bool");
+		Assert.IsTrue(types.Any(t => t is SchemaTypes.Float), "GetAvailableTypes should include Float");
+		Assert.IsTrue(types.Count > 1, "GetAvailableTypes should offer more than just None");
+	}
+
+	[TestMethod]
+	public void TestGetAvailableTypesIncludesDefinedEnumsAndClasses()
+	{
+		Schema schemaProvider = new();
+		schemaProvider.AddEnum("Status".As<EnumName>());
+		schemaProvider.AddClass("User".As<ClassName>());
+
+		List<SchemaTypes.BaseType> types = [.. schemaProvider.GetAvailableTypes()];
+
+		Assert.IsTrue(
+			types.Any(t => t is SchemaTypes.Enum e && e.EnumName == "Status".As<EnumName>()),
+			"GetAvailableTypes should include an Enum for each defined enum");
+		Assert.IsTrue(
+			types.Any(t => t is SchemaTypes.Object o && o.ClassName == "User".As<ClassName>()),
+			"GetAvailableTypes should include an Object for each defined class");
+		Assert.IsTrue(
+			types.Any(t => t is SchemaTypes.Array a && a.ElementType is SchemaTypes.Object o && o.ClassName == "User".As<ClassName>()),
+			"GetAvailableTypes should include an Array of each defined class");
+	}
+
+	[TestMethod]
+	public void TestGetAvailableTypesReturnsDistinctInstances()
+	{
+		Schema schemaProvider = new();
+
+		List<SchemaTypes.BaseType> types = [.. schemaProvider.GetAvailableTypes()];
+
+		// Each entry must be a unique instance so selecting one does not mutate another.
+		HashSet<SchemaTypes.BaseType> uniqueInstances = new(ReferenceEqualityComparer.Instance);
+		foreach (SchemaTypes.BaseType type in types)
+		{
+			Assert.IsTrue(uniqueInstances.Add(type), "GetAvailableTypes should return distinct instances");
+
+			if (type is SchemaTypes.Array array)
+			{
+				Assert.IsTrue(uniqueInstances.Add(array.ElementType), "Array element types should be distinct instances");
+			}
+		}
+	}
+
+	[TestMethod]
 	public void TestTryGetEnum()
 	{
 		Schema schemaProvider = new();

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -559,4 +559,47 @@ public partial class Schema
 	/// <returns>Collection of all schema types.</returns>
 	public IEnumerable<BaseType> GetTypes() =>
 		GetDiscreteTypes().GroupBy(t => t.GetType()).Select(g => g.First());
+
+	/// <summary>
+	/// Gets every type a member can be assigned, suitable for populating a type picker.
+	/// This includes the built-in types, an <see cref="Enum"/> for each defined enum,
+	/// an <see cref="Object"/> for each defined class, and an <see cref="Array"/> of each
+	/// of those element types.
+	/// </summary>
+	/// <returns>Collection of all selectable schema types.</returns>
+	public IEnumerable<BaseType> GetAvailableTypes()
+	{
+		yield return new None();
+
+		foreach (BaseType elementType in GetSelectableElementTypes())
+		{
+			yield return elementType;
+		}
+
+		foreach (BaseType elementType in GetSelectableElementTypes())
+		{
+			yield return new Array() { ElementType = elementType };
+		}
+	}
+
+	private IEnumerable<BaseType> GetSelectableElementTypes()
+	{
+		foreach (BaseType builtInType in BaseType.GetBuiltInTypes())
+		{
+			if (builtInType is not None)
+			{
+				yield return builtInType;
+			}
+		}
+
+		foreach (SchemaEnum schemaEnum in EnumsInternal)
+		{
+			yield return new Enum() { EnumName = schemaEnum.Name };
+		}
+
+		foreach (SchemaClass schemaClass in ClassesInternal)
+		{
+			yield return new Object() { ClassName = schemaClass.Name };
+		}
+	}
 }

--- a/Schema/Models/Types/BaseType.cs
+++ b/Schema/Models/Types/BaseType.cs
@@ -137,6 +137,29 @@ public abstract class BaseType : IEquatable<BaseType?>
 	];
 
 	/// <summary>
+	/// Creates fresh instances of every built-in type.
+	/// </summary>
+	/// <returns>A new instance of each built-in type.</returns>
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Allocates new instances on each call, which is not appropriate for a property.")]
+	public static IEnumerable<BaseType> GetBuiltInTypes() =>
+	[
+		new None(),
+		new Bool(),
+		new Int(),
+		new Long(),
+		new Float(),
+		new Double(),
+		new String(),
+		new DateTime(),
+		new TimeSpan(),
+		new Vector2(),
+		new Vector3(),
+		new Vector4(),
+		new ColorRGB(),
+		new ColorRGBA(),
+	];
+
+	/// <summary>
 	/// Gets a value indicating whether the type is built-in.
 	/// </summary>
 	[JsonIgnore]

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -354,7 +354,7 @@ public class SchemaEditor
 
 		if (ImGui.Button($"{schemaMember.Type.DisplayName}##Type{schemaMember.Name}", new Vector2(FieldWidth, 0)))
 		{
-			Popups.OpenTypeList("Select Type", "Type", schema.GetTypes(), schemaMember.Type, schemaMember.SetType);
+			Popups.OpenTypeList("Select Type", "Type", schema.GetAvailableTypes(), schemaMember.Type, schemaMember.SetType);
 		}
 
 		if (schemaMember.Type is SchemaTypes.Array array)

--- a/SchemaEditor/TreeClass.cs
+++ b/SchemaEditor/TreeClass.cs
@@ -163,7 +163,7 @@ internal sealed class TreeClass(SchemaEditor schemaEditor)
 					if (addedMember is not null)
 					{
 						Debug.Assert(addedMember.ParentSchema is not null);
-						Popups.OpenTypeList("Select Type", "Type", addedMember.ParentSchema.GetTypes(), addedMember.Type, addedMember.SetType);
+						Popups.OpenTypeList("Select Type", "Type", addedMember.ParentSchema.GetAvailableTypes(), addedMember.Type, addedMember.SetType);
 					}
 				});
 			}


### PR DESCRIPTION
## Problem

When choosing the type for a schema member in the editor, the selection list contained no items other than "None".

## Root cause

Both type pickers in the editor were populated from `Schema.GetTypes()`, which only returns the distinct types **already in use** by existing members. On a fresh schema (or for a brand-new member defaulting to `None`), no other types have been used yet, so the picker showed only "None".

## Fix

Added `Schema.GetAvailableTypes()`, which returns the full set of selectable types:

- every built-in type (`None`, `Bool`, `Int`, `Long`, `Float`, `Double`, `String`, `DateTime`, `TimeSpan`, `Vector2/3/4`, `ColorRGB/RGBA`)
- an `Enum` for each enum defined in the schema
- an `Object` for each class defined in the schema
- an `Array` of each of the above element types (so collections, including the keyed-object containers the editor already supports, can be created)

A new `BaseType.GetBuiltInTypes()` helper enumerates fresh instances of the built-in types. Each entry returned by `GetAvailableTypes()` is a distinct instance, so selecting one type can never mutate another (important because array element types are `init`-only and only settable at construction).

The two editor call sites (`SchemaEditor.ShowMemberConfig` and `TreeClass`) now use `GetAvailableTypes()`. `GetTypes()` is left unchanged since it is used elsewhere for reporting types actually in use.

## Tests

Added three tests covering the new behavior (empty schema offers built-ins, defined enums/classes appear including their array variants, and all returned instances are distinct). Full suite: **146/146 passing**.

https://claude.ai/code/session_01Pvnx3kUPchjzFsRhvchzvc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pvnx3kUPchjzFsRhvchzvc)_