### PR TITLE
chore: update ktsu.Sdk to 2.21.1 [patch]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,9 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+# LF on every platform, matching the `* text=auto eol=lf` default in .gitattributes.
+# Overrides below must stay in step with the eol pins in that file.
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -17,7 +19,7 @@ trim_trailing_whitespace = true
 [*.{cs,csx,cake,fs,fsx,vb,vbx}]
 indent_style = tab
 
-file_header_template = Copyright (c) ktsu.dev\nAll rights reserved.\nLicensed under the MIT license.
+file_header_template = Copyright (c) 2023-2026 ktsu-dev contributors
 
 # Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = error
@@ -504,3 +506,8 @@ indent_style = tab
 [*.sh]
 end_of_line = lf
 indent_size = 2
+
+# Windows batch scripts and Visual Studio solution files keep CRLF on every platform.
+# These match the eol=crlf pins in .gitattributes.
+[*.{cmd,bat,sln}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,17 +4,25 @@
 # Git Line Endings            #
 ###############################
 
-# Set default behaviour to automatically normalize line endings.
-* text=auto
+# Normalize all text files to LF in the repository, and check them out as LF on every
+# platform. The explicit eol overrides each machine's core.autocrlf, so the working tree
+# is byte-identical on Windows, Linux and macOS. This must stay in step with the
+# end_of_line settings in .editorconfig.
+* text=auto eol=lf
+
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work. Redundant with the
+# default above, kept explicit because these files break outright with CRLF.
+*.sh text eol=lf
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 
-# Force bash scripts to always use LF line endings so that if a repo is accessed
-# in Unix via a file share from Windows, the scripts will work.
-*.sh text eol=lf
+# Visual Studio rewrites solution files with CRLF regardless of the checkout, so pin
+# them to avoid a spurious whole-file diff every time the solution is opened.
+*.sln text eol=crlf
 
 ###############################
 # Git Large File System (LFS) #

--- a/.runsettings
+++ b/.runsettings
@@ -1,25 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
-  <!-- Specify a deterministic output directory -->
   <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
+    <ResultsDirectory>TestResults</ResultsDirectory>
   </RunConfiguration>
-  <!-- Specify a deterministic output directory -->
-  <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
-  </RunConfiguration>
-
-  <!-- Configuration for coverlet data collector -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="coverlet.collector.DataCollectors.CoverletInProcDataCollector, coverlet.collector, Version=6.0.4.0, Culture=neutral, PublicKeyToken=null">
-        <Configuration>
-          <Format>opencover</Format>
-          <OutputPath>coverage.opencover.xml</OutputPath>
-          <Exclude>[*Test*]*,[*Tests*]*</Exclude>
-          <ExcludeByFile>**/obj/**/*</ExcludeByFile>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="ktsu.AppDataStorage" Version="1.16.33" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="10.0.301" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
     <PackageVersion Include="Polyfill" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/Schema.Test/AddClassFromTypeTests.cs
+++ b/Schema.Test/AddClassFromTypeTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/AssemblyInfo.cs
+++ b/Schema.Test/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 [assembly: Parallelize(Workers = 0, Scope = ExecutionScope.MethodLevel)]

--- a/Schema.Test/SchemaClassTests.cs
+++ b/Schema.Test/SchemaClassTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/SchemaEnumTests.cs
+++ b/Schema.Test/SchemaEnumTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/SchemaSerializerTests.cs
+++ b/Schema.Test/SchemaSerializerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/SchemaTests.cs
+++ b/Schema.Test/SchemaTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/SchemaValidationTests.cs
+++ b/Schema.Test/SchemaValidationTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema.Test/TypeSystemTests.cs
+++ b/Schema.Test/TypeSystemTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Tests;
 

--- a/Schema/AssemblyInfo.cs
+++ b/Schema/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.Schema.Test")]

--- a/Schema/Contracts/ISchema.cs
+++ b/Schema/Contracts/ISchema.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaChild.cs
+++ b/Schema/Contracts/ISchemaChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaChildDescription.cs
+++ b/Schema/Contracts/ISchemaChildDescription.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaChildSet.cs
+++ b/Schema/Contracts/ISchemaChildSet.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaChildSummary.cs
+++ b/Schema/Contracts/ISchemaChildSummary.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaClass.cs
+++ b/Schema/Contracts/ISchemaClass.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaClassChild.cs
+++ b/Schema/Contracts/ISchemaClassChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaEnum.cs
+++ b/Schema/Contracts/ISchemaEnum.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaEnumValue.cs
+++ b/Schema/Contracts/ISchemaEnumValue.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaMember.cs
+++ b/Schema/Contracts/ISchemaMember.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaMemberChild.cs
+++ b/Schema/Contracts/ISchemaMemberChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/ISchemaType.cs
+++ b/Schema/Contracts/ISchemaType.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts;
 

--- a/Schema/Contracts/Names/ISchemaChildName.cs
+++ b/Schema/Contracts/Names/ISchemaChildName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaClassChildName.cs
+++ b/Schema/Contracts/Names/ISchemaClassChildName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaClassName.cs
+++ b/Schema/Contracts/Names/ISchemaClassName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaCodeGeneratorName.cs
+++ b/Schema/Contracts/Names/ISchemaCodeGeneratorName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaDataSourceName.cs
+++ b/Schema/Contracts/Names/ISchemaDataSourceName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaEnumName.cs
+++ b/Schema/Contracts/Names/ISchemaEnumName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaEnumValueName.cs
+++ b/Schema/Contracts/Names/ISchemaEnumValueName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaMemberChildName.cs
+++ b/Schema/Contracts/Names/ISchemaMemberChildName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaMemberName.cs
+++ b/Schema/Contracts/Names/ISchemaMemberName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaName.cs
+++ b/Schema/Contracts/Names/ISchemaName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaRootName.cs
+++ b/Schema/Contracts/Names/ISchemaRootName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Contracts/Names/ISchemaTypeName.cs
+++ b/Schema/Contracts/Names/ISchemaTypeName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Contracts.Names;
 

--- a/Schema/Models/DataSource.cs
+++ b/Schema/Models/DataSource.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/Names/BaseTypeName.cs
+++ b/Schema/Models/Names/BaseTypeName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/ClassName.cs
+++ b/Schema/Models/Names/ClassName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/CodeGeneratorName.cs
+++ b/Schema/Models/Names/CodeGeneratorName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/ContainerName.cs
+++ b/Schema/Models/Names/ContainerName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/DataSourceName.cs
+++ b/Schema/Models/Names/DataSourceName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/EnumName.cs
+++ b/Schema/Models/Names/EnumName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/EnumValueName.cs
+++ b/Schema/Models/Names/EnumValueName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Names/MemberName.cs
+++ b/Schema/Models/Names/MemberName.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Names;
 

--- a/Schema/Models/Schema.Validation.cs
+++ b/Schema/Models/Schema.Validation.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaChild.cs
+++ b/Schema/Models/SchemaChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaChildDescription.cs
+++ b/Schema/Models/SchemaChildDescription.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaChildNameComparer.cs
+++ b/Schema/Models/SchemaChildNameComparer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaChildSet.cs
+++ b/Schema/Models/SchemaChildSet.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaChildSummary.cs
+++ b/Schema/Models/SchemaChildSummary.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaClass.cs
+++ b/Schema/Models/SchemaClass.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaClassChild.cs
+++ b/Schema/Models/SchemaClassChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaCodeGenerator.cs
+++ b/Schema/Models/SchemaCodeGenerator.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaEnum.cs
+++ b/Schema/Models/SchemaEnum.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaEnumValue.cs
+++ b/Schema/Models/SchemaEnumValue.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaMember.cs
+++ b/Schema/Models/SchemaMember.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaMemberChild.cs
+++ b/Schema/Models/SchemaMemberChild.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/SchemaValidationIssue.cs
+++ b/Schema/Models/SchemaValidationIssue.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/Schema/Models/Types/Array.cs
+++ b/Schema/Models/Types/Array.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/BaseType.cs
+++ b/Schema/Models/Types/BaseType.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Bool.cs
+++ b/Schema/Models/Types/Bool.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/ColorRGB.cs
+++ b/Schema/Models/Types/ColorRGB.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/ColorRGBA.cs
+++ b/Schema/Models/Types/ColorRGBA.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/DateTime.cs
+++ b/Schema/Models/Types/DateTime.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Double.cs
+++ b/Schema/Models/Types/Double.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Enum.cs
+++ b/Schema/Models/Types/Enum.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Float.cs
+++ b/Schema/Models/Types/Float.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Int.cs
+++ b/Schema/Models/Types/Int.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Long.cs
+++ b/Schema/Models/Types/Long.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/None.cs
+++ b/Schema/Models/Types/None.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Object.cs
+++ b/Schema/Models/Types/Object.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/SchemaTypes.cs
+++ b/Schema/Models/Types/SchemaTypes.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 /// <summary>

--- a/Schema/Models/Types/String.cs
+++ b/Schema/Models/Types/String.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/SystemObject.cs
+++ b/Schema/Models/Types/SystemObject.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/TimeSpan.cs
+++ b/Schema/Models/Types/TimeSpan.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Vector.cs
+++ b/Schema/Models/Types/Vector.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Vector2.cs
+++ b/Schema/Models/Types/Vector2.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Vector3.cs
+++ b/Schema/Models/Types/Vector3.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Models/Types/Vector4.cs
+++ b/Schema/Models/Types/Vector4.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models.Types;
 

--- a/Schema/Schema.csproj
+++ b/Schema/Schema.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="ktsu.Semantics.Paths" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Polyfill" />
   </ItemGroup>
 </Project>

--- a/Schema/SchemaSerializer.cs
+++ b/Schema/SchemaSerializer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.Schema.Models;
 

--- a/SchemaEditor/AppData.cs
+++ b/SchemaEditor/AppData.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.Schema.Test")]
 

--- a/SchemaEditor/ButtonTree.cs
+++ b/SchemaEditor/ButtonTree.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/ClassGraphView.cs
+++ b/SchemaEditor/ClassGraphView.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/Popups.cs
+++ b/SchemaEditor/Popups.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
@@ -196,7 +194,7 @@ public class SchemaEditor
 	{
 		// Stashed for the parameterless tab content delegates (the Class Graph needs the frame delta).
 		currentDeltaTime = dt;
-		using (Theme.FromColor(Color.Palette.Semantic.Primary))
+		using (Theme.FromColor(Palette.Semantic.Primary))
 		{
 			DividerContainerCols.Tick(dt);
 			Popups.Update();
@@ -447,7 +445,7 @@ public class SchemaEditor
 		{
 			if (string.IsNullOrEmpty(CurrentSchemaPath))
 			{
-				using (Theme.FromColor(Color.Palette.Semantic.Error))
+				using (Theme.FromColor(Palette.Semantic.Error))
 				{
 					ImGui.TextUnformatted("Schema has not been saved. Save it before configuring relative paths.");
 

--- a/SchemaEditor/SchemaFile.cs
+++ b/SchemaEditor/SchemaFile.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/TreeClass.cs
+++ b/SchemaEditor/TreeClass.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/TreeCodeGenerator.cs
+++ b/SchemaEditor/TreeCodeGenerator.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/TreeDataSource.cs
+++ b/SchemaEditor/TreeDataSource.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/TreeEnum.cs
+++ b/SchemaEditor/TreeEnum.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/SchemaEditor/TreeSchema.cs
+++ b/SchemaEditor/TreeSchema.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.SchemaEditor;
 

--- a/global.json
+++ b/global.json
@@ -5,14 +5,14 @@
   },
   "msbuild-sdks": {
     "MSTest.Sdk": "4.3.3",
-    "ktsu.Sdk": "2.18.0",
-    "ktsu.Sdk.ConsoleApp": "2.18.0",
-    "ktsu.Sdk.App": "2.18.0",
-    "ktsu.Sdk.Windows": "2.18.0",
-    "ktsu.Sdk.Linux": "2.18.0",
-    "ktsu.Sdk.macOS": "2.18.0",
-    "ktsu.Sdk.iOS": "2.18.0",
-    "ktsu.Sdk.Android": "2.18.0"
+    "ktsu.Sdk": "2.21.1",
+    "ktsu.Sdk.ConsoleApp": "2.21.1",
+    "ktsu.Sdk.App": "2.21.1",
+    "ktsu.Sdk.Windows": "2.21.1",
+    "ktsu.Sdk.Linux": "2.21.1",
+    "ktsu.Sdk.macOS": "2.21.1",
+    "ktsu.Sdk.iOS": "2.21.1",
+    "ktsu.Sdk.Android": "2.21.1"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
Bumps ktsu.Sdk and its variants to 2.21.1 in global.json.  File headers are migrated to the single line from COPYRIGHT.md, which is what the SDK writes into .editorconfig as file_header_template and IDE0073 enforces.  Updates Color.Palette.* to Palette.* for ktsu.ImGui.Styler 3.3.9, and adds the System.Text.Json PackageReference required by KTSU0006.  

Generated with [Claude Code](https://claude.com/claude-code)
