### PR TITLE
Fix the build blocker and the four correctness bugs (#123, #106, #107, #108, #109, #111)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -156,7 +156,13 @@ jobs:
       - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+          # Schema.Test multi-targets every framework the library publishes, so the
+          # test hosts for net8.0 and net9.0 need those runtimes present alongside the
+          # SDK. global.json pins the SDK, so the extra versions only add runtimes.
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            ${{ env.DOTNET_VERSION }}.x
           cache: true
           cache-dependency-path: |
             **/*.csproj
@@ -255,7 +261,13 @@ jobs:
       - name: Setup .NET SDK ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}.x
+          # Schema.Test multi-targets every framework the library publishes, so the
+          # test hosts for net8.0 and net9.0 need those runtimes present alongside the
+          # SDK. global.json pins the SDK, so the extra versions only add runtimes.
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            ${{ env.DOTNET_VERSION }}.x
           cache: true
           cache-dependency-path: |
             **/*.csproj

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Or add to your project file:
 
 ### Requirements
 
-- .NET 7.0, 8.0, 9.0, or 10.0
+- .NET 8.0, 9.0, or 10.0
 
 ## Quick Start
 
@@ -239,6 +239,12 @@ dotnet run --project SchemaEditor
 - Resizable split-panel layout with persistent settings
 
 ## Building
+
+Building the solution requires the **.NET SDK 10.0.400 or newer**. This is the floor
+pinned in `global.json`: the analyzers shipped by `ktsu.Sdk` are built against the
+Roslyn version in that feature band, and an older 10.0.x SDK fails the build with
+`CS9057` before compiling any source. An SDK newer than the floor is fine —
+`global.json` sets `rollForward: latestFeature`.
 
 ```shell
 # Build the entire solution

--- a/Schema.Test/Schema.Test.csproj
+++ b/Schema.Test/Schema.Test.csproj
@@ -1,11 +1,9 @@
-﻿<Project>
+<Project>
   <Sdk Name="MSTest.Sdk" />
-  <Sdk Name="ktsu.Sdk" />
+  <Import Project="Sdk.props" Sdk="ktsu.Sdk" />
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFramework>net10.0</TargetFramework>
-    <TargetFrameworks></TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,5 +15,16 @@
       <VersionOverride>18.8.0</VersionOverride>
     </PackageReference>
   </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="ktsu.Sdk" />
+
+  <!-- ktsu.Sdk pins test projects to a single framework (it sets TargetFramework in its
+       props and clears TargetFrameworks in its targets). Schema publishes three frameworks,
+       so the suite has to run on all three - see issue #109. This PropertyGroup is placed
+       after the explicit Sdk.targets import so the project, not the SDK, has the last word. -->
+  <PropertyGroup>
+    <TargetFramework></TargetFramework>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
 
 </Project>

--- a/Schema.Test/SchemaSerializerTests.cs
+++ b/Schema.Test/SchemaSerializerTests.cs
@@ -31,6 +31,44 @@ public class SchemaSerializerTests
 	}
 
 	[TestMethod]
+	public void TestVectorAndColorMembersSerializeWithoutAClassName()
+	{
+		Schema original = new();
+		SchemaClass? playerClass = original.AddClass("Player".As<ClassName>());
+		Assert.IsNotNull(playerClass);
+		playerClass.AddMember("Position".As<MemberName>())?.SetType(new SchemaTypes.Vector3());
+		playerClass.AddMember("Tint".As<MemberName>())?.SetType(new SchemaTypes.ColorRGB());
+
+		string json = SchemaSerializer.Serialize(original);
+
+		// Before issue #107 these types derived from Object and wrote an empty "className".
+		Assert.IsFalse(json.Contains("className", StringComparison.Ordinal), json);
+		Assert.IsTrue(json.Contains("Vector3", StringComparison.Ordinal), json);
+		Assert.IsTrue(json.Contains("ColorRGB", StringComparison.Ordinal), json);
+	}
+
+	[TestMethod]
+	public void TestRoundtripWithVectorAndColorMembers()
+	{
+		Schema original = new();
+		SchemaClass? playerClass = original.AddClass("Player".As<ClassName>());
+		Assert.IsNotNull(playerClass);
+		playerClass.AddMember("Position".As<MemberName>())?.SetType(new SchemaTypes.Vector3());
+		playerClass.AddMember("Tint".As<MemberName>())?.SetType(new SchemaTypes.ColorRGBA());
+
+		string json = SchemaSerializer.Serialize(original);
+		Assert.IsTrue(SchemaSerializer.TryDeserialize(json, out Schema? deserialized));
+		Assert.IsNotNull(deserialized);
+
+		SchemaClass? roundTripped = deserialized.GetClass("Player".As<ClassName>());
+		Assert.IsNotNull(roundTripped);
+		Assert.IsTrue(roundTripped.TryGetMember("Position".As<MemberName>(), out SchemaMember? position));
+		Assert.IsTrue(roundTripped.TryGetMember("Tint".As<MemberName>(), out SchemaMember? tint));
+		Assert.AreEqual(new SchemaTypes.Vector3(), position!.Type);
+		Assert.AreEqual(new SchemaTypes.ColorRGBA(), tint!.Type);
+	}
+
+	[TestMethod]
 	public void TestRoundtripWithClasses()
 	{
 		Schema original = new();
@@ -49,6 +87,8 @@ public class SchemaSerializerTests
 		Assert.IsTrue(deserialized.TryGetClass("User".As<ClassName>(), out SchemaClass? deserializedClass));
 		Assert.IsNotNull(deserializedClass);
 		Assert.AreEqual(1, deserializedClass.Members.Count);
+		Assert.IsTrue(deserializedClass.TryGetMember("Name".As<MemberName>(), out SchemaMember? deserializedMember));
+		Assert.AreEqual(new SchemaTypes.String(), deserializedMember!.Type);
 	}
 
 	[TestMethod]
@@ -109,6 +149,14 @@ public class SchemaSerializerTests
 		Assert.IsTrue(deserialized.TryGetClass("Test".As<ClassName>(), out SchemaClass? deserializedClass));
 		Assert.IsNotNull(deserializedClass);
 		Assert.AreEqual(types.Length, deserializedClass.Members.Count);
+
+		// Counting the members is not enough: the member type is what the format exists to
+		// carry, so assert each one survived the round trip.
+		for (int index = 0; index < types.Length; index++)
+		{
+			Assert.IsTrue(deserializedClass.TryGetMember($"Field{index}".As<MemberName>(), out SchemaMember? member));
+			Assert.AreEqual(types[index], member!.Type);
+		}
 	}
 
 	[TestMethod]

--- a/Schema.Test/SchemaValidationTests.cs
+++ b/Schema.Test/SchemaValidationTests.cs
@@ -184,6 +184,159 @@ public class SchemaValidationTests
 	}
 
 	[TestMethod]
+	public void TestEmptyClassNameIsError()
+	{
+		Schema schema = new();
+		schema.AddClass(string.Empty.As<ClassName>());
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Error &&
+			i.Path == "(unnamed)" &&
+			i.Message.Contains("Class has an empty name")));
+	}
+
+	[TestMethod]
+	public void TestEmptyEnumDeclarationNameIsError()
+	{
+		Schema schema = new();
+		schema.AddEnum(string.Empty.As<EnumName>());
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Error &&
+			i.Path == "(unnamed)" &&
+			i.Message.Contains("Enum has an empty name")));
+	}
+
+	[TestMethod]
+	public void TestEmptyMemberNameIsError()
+	{
+		Schema schema = new();
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		SchemaMember? member = userClass?.AddMember(string.Empty.As<MemberName>());
+		member?.SetType(new SchemaTypes.Int());
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Error &&
+			i.Path == "User.(unnamed)" &&
+			i.Message.Contains("Member has an empty name")));
+	}
+
+	[TestMethod]
+	public void TestEmptyEnumValueNameIsError()
+	{
+		// TryAddValue rejects an empty value, so this state is only reachable by loading a
+		// hand-edited schema file - which is exactly what the validator is there to catch.
+		const string json = """
+		{
+		  "classes": [],
+		  "enums": [ { "name": "Status", "values": [ "Active", "" ] } ],
+		  "dataSources": [],
+		  "codeGenerators": []
+		}
+		""";
+
+		Assert.IsTrue(SchemaSerializer.TryDeserialize(json, out Schema? schema));
+		Assert.IsNotNull(schema);
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(
+			issues.Any(i =>
+				i.Severity == SchemaValidationSeverity.Error &&
+				i.Path == "Status.(unnamed)" &&
+				i.Message.Contains("Enum value has an empty name")),
+			string.Join("; ", issues));
+	}
+
+	[TestMethod]
+	public void TestMemberWithoutATypeIsWarning()
+	{
+		Schema schema = new();
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		userClass?.AddMember("Name".As<MemberName>());
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Warning &&
+			i.Path == "User.Name" &&
+			i.Message.Contains("does not have a type set")));
+	}
+
+	[TestMethod]
+	public void TestArrayWithoutAContainerIsWarning()
+	{
+		Schema schema = new();
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		SchemaMember? tags = userClass?.AddMember("Tags".As<MemberName>());
+		tags?.SetType(new SchemaTypes.Array() { ElementType = new SchemaTypes.String() });
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Warning &&
+			i.Path == "User.Tags" &&
+			i.Message.Contains("does not specify a container")));
+	}
+
+	[TestMethod]
+	public void TestArrayWithUnrecognizedContainerIsWarning()
+	{
+		Schema schema = new();
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		SchemaMember? tags = userClass?.AddMember("Tags".As<MemberName>());
+		tags?.SetType(new SchemaTypes.Array()
+		{
+			ElementType = new SchemaTypes.String(),
+			Container = "linked-list".As<ContainerName>(),
+		});
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Warning &&
+			i.Path == "User.Tags" &&
+			i.Message.Contains("linked-list")));
+	}
+
+	[TestMethod]
+	public void TestKnownContainersValidateClean()
+	{
+		Schema schema = new();
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		SchemaMember? tags = userClass?.AddMember("Tags".As<MemberName>());
+		tags?.SetType(new SchemaTypes.Array()
+		{
+			ElementType = new SchemaTypes.String(),
+			Container = SchemaTypes.Array.VectorContainer.As<ContainerName>(),
+		});
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.AreEqual(0, issues.Count, string.Join("; ", issues));
+	}
+
+	[TestMethod]
+	public void TestMapWithoutAKeyIsError()
+	{
+		Schema schema = new();
+		SchemaClass? itemClass = schema.AddClass("Item".As<ClassName>());
+		itemClass?.AddMember("Id".As<MemberName>())?.SetType(new SchemaTypes.Int());
+
+		SchemaClass? userClass = schema.AddClass("User".As<ClassName>());
+		SchemaMember? items = userClass?.AddMember("Items".As<MemberName>());
+		items?.SetType(new SchemaTypes.Array()
+		{
+			ElementType = new SchemaTypes.Object() { ClassName = "Item".As<ClassName>() },
+			Container = SchemaTypes.Array.MapContainer.As<ContainerName>(),
+		});
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.IsTrue(issues.Any(i =>
+			i.Severity == SchemaValidationSeverity.Error &&
+			i.Path == "User.Items" &&
+			i.Message.Contains("does not specify a key")));
+	}
+
+	[TestMethod]
 	public void TestUnconfiguredDataSourceIsWarning()
 	{
 		Schema schema = new();

--- a/Schema.Test/SchemaValidationTests.cs
+++ b/Schema.Test/SchemaValidationTests.cs
@@ -48,6 +48,23 @@ public class SchemaValidationTests
 	}
 
 	[TestMethod]
+	public void TestVectorAndColorMembersHaveNoIssues()
+	{
+		// Before issue #107 these types derived from Object, so the validator saw an empty
+		// inherited ClassName and reported "Object type does not specify a class name."
+		Schema schema = new();
+		SchemaClass? playerClass = schema.AddClass("Player".As<ClassName>());
+		playerClass?.AddMember("Position".As<MemberName>())?.SetType(new SchemaTypes.Vector3());
+		playerClass?.AddMember("Tint".As<MemberName>())?.SetType(new SchemaTypes.ColorRGB());
+		playerClass?.AddMember("Velocity".As<MemberName>())?.SetType(new SchemaTypes.Vector2());
+		playerClass?.AddMember("Rotation".As<MemberName>())?.SetType(new SchemaTypes.Vector4());
+		playerClass?.AddMember("Overlay".As<MemberName>())?.SetType(new SchemaTypes.ColorRGBA());
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.AreEqual(0, issues.Count, string.Join("; ", issues));
+	}
+
+	[TestMethod]
 	public void TestEmptySchemaHasNoIssues()
 	{
 		Schema schema = new();

--- a/Schema.Test/TypeSystemTests.cs
+++ b/Schema.Test/TypeSystemTests.cs
@@ -102,49 +102,46 @@ public class TypeSystemTests
 	}
 
 	[TestMethod]
-	public void TestVector2Type()
+	[DataRow(typeof(Vector2), "Vector2")]
+	[DataRow(typeof(Vector3), "Vector3")]
+	[DataRow(typeof(Vector4), "Vector4")]
+	[DataRow(typeof(ColorRGB), "ColorRGB")]
+	[DataRow(typeof(ColorRGBA), "ColorRGBA")]
+	public void TestSystemObjectTypeClassification(Type clrType, string expectedName)
 	{
-		Vector2 type = new();
+		BaseType type = (BaseType)Activator.CreateInstance(clrType)!;
 		Assert.IsFalse(type.IsPrimitive);
 		Assert.IsTrue(type.IsBuiltIn);
-		Assert.IsTrue(type.IsObject);
 		Assert.IsTrue(type.IsSystemObject);
+
+		// A vector or color is structured, but it is not a reference to a user-defined class,
+		// which is what IsObject means. See issue #107.
+		Assert.IsFalse(type.IsObject);
+
+		Assert.AreEqual(expectedName, type.ToString());
+		Assert.AreEqual(expectedName, type.DisplayName);
 	}
 
 	[TestMethod]
-	public void TestVector3Type()
+	[DataRow("Vector2")]
+	[DataRow("Vector3")]
+	[DataRow("Vector4")]
+	[DataRow("ColorRGB")]
+	[DataRow("ColorRGBA")]
+	public void TestSystemObjectTypeRoundTripsThroughCreateFromString(string typeName)
 	{
-		Vector3 type = new();
-		Assert.IsFalse(type.IsPrimitive);
-		Assert.IsTrue(type.IsBuiltIn);
-		Assert.IsTrue(type.IsObject);
+		object? recreated = BaseType.CreateFromString(typeName);
+		Assert.IsNotNull(recreated);
+		Assert.AreEqual(typeName, recreated.ToString());
 	}
 
 	[TestMethod]
-	public void TestVector4Type()
+	public void TestSystemObjectAndVectorAreAbstract()
 	{
-		Vector4 type = new();
-		Assert.IsFalse(type.IsPrimitive);
-		Assert.IsTrue(type.IsBuiltIn);
-		Assert.IsTrue(type.IsObject);
-	}
-
-	[TestMethod]
-	public void TestColorRGBType()
-	{
-		ColorRGB type = new();
-		Assert.IsFalse(type.IsPrimitive);
-		Assert.IsTrue(type.IsBuiltIn);
-		Assert.IsTrue(type.IsObject);
-	}
-
-	[TestMethod]
-	public void TestColorRGBAType()
-	{
-		ColorRGBA type = new();
-		Assert.IsFalse(type.IsPrimitive);
-		Assert.IsTrue(type.IsBuiltIn);
-		Assert.IsTrue(type.IsObject);
+		// Neither is registered as a [JsonDerivedType] on BaseType, so an instance of either
+		// would fail to serialize. They exist only as intermediate bases.
+		Assert.IsTrue(typeof(SystemObject).IsAbstract);
+		Assert.IsTrue(typeof(Vector).IsAbstract);
 	}
 
 	[TestMethod]
@@ -207,6 +204,123 @@ public class TypeSystemTests
 		Int a = new();
 		Int b = new();
 		Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+	}
+
+	[TestMethod]
+	public void TestDistinctInstancesOfSameTypeAreEqual()
+	{
+		Assert.IsTrue(new Int().Equals(new Int()));
+		Assert.IsTrue(new String().Equals(new String()));
+		Assert.IsTrue(new Vector3().Equals(new Vector3()));
+	}
+
+	[TestMethod]
+	public void TestDerivedSystemObjectTypesAreNotEqualToTheirBase()
+	{
+		// ColorRGB derives from Vector3, but they are distinct schema types.
+		Assert.IsFalse(new ColorRGB().Equals(new Vector3()));
+		Assert.IsFalse(new Vector3().Equals(new ColorRGB()));
+	}
+
+	[TestMethod]
+	public void TestObjectEqualityComparesClassName()
+	{
+		Object a = new() { ClassName = "A".As<ClassName>() };
+		Object b = new() { ClassName = "B".As<ClassName>() };
+		Object anotherA = new() { ClassName = "A".As<ClassName>() };
+
+		Assert.IsFalse(a.Equals(b));
+		Assert.IsTrue(a.Equals(anotherA));
+		Assert.AreEqual(a.GetHashCode(), anotherA.GetHashCode());
+	}
+
+	[TestMethod]
+	public void TestEnumEqualityComparesEnumName()
+	{
+		Enum a = new() { EnumName = "Color".As<EnumName>() };
+		Enum b = new() { EnumName = "Shape".As<EnumName>() };
+		Enum anotherA = new() { EnumName = "Color".As<EnumName>() };
+
+		Assert.IsFalse(a.Equals(b));
+		Assert.IsTrue(a.Equals(anotherA));
+		Assert.AreEqual(a.GetHashCode(), anotherA.GetHashCode());
+	}
+
+	[TestMethod]
+	public void TestArrayEqualityComparesElementTypeContainerAndKey()
+	{
+		Array intVector = new() { ElementType = new Int(), Container = "vector".As<ContainerName>() };
+		Array stringVector = new() { ElementType = new String(), Container = "vector".As<ContainerName>() };
+		Array intMap = new() { ElementType = new Int(), Container = "map".As<ContainerName>() };
+		Array keyedIntVector = new()
+		{
+			ElementType = new Int(),
+			Container = "vector".As<ContainerName>(),
+			Key = "Id".As<MemberName>(),
+		};
+		Array anotherIntVector = new() { ElementType = new Int(), Container = "vector".As<ContainerName>() };
+
+		Assert.IsFalse(intVector.Equals(stringVector));
+		Assert.IsFalse(intVector.Equals(intMap));
+		Assert.IsFalse(intVector.Equals(keyedIntVector));
+		Assert.IsTrue(intVector.Equals(anotherIntVector));
+		Assert.AreEqual(intVector.GetHashCode(), anotherIntVector.GetHashCode());
+	}
+
+	[TestMethod]
+	public void TestEqualInstancesDedupeInAHashSet()
+	{
+		HashSet<BaseType> types =
+		[
+			new Int(),
+			new Int(),
+			new String(),
+			new Object() { ClassName = "A".As<ClassName>() },
+			new Object() { ClassName = "A".As<ClassName>() },
+			new Object() { ClassName = "B".As<ClassName>() },
+		];
+
+		Assert.AreEqual(4, types.Count);
+	}
+
+	[TestMethod]
+	public void TestEqualityOperators()
+	{
+		Int a = new();
+		Int b = new();
+		String s = new();
+
+		Assert.IsTrue(a == b);
+		Assert.IsFalse(a != b);
+		Assert.IsTrue(a != s);
+		Assert.IsFalse(a == s);
+	}
+
+	[TestMethod]
+	public void TestEqualityOperatorsWithNull()
+	{
+		// Indirected through an array so the operands are not constant-folded away.
+		BaseType?[] operands = [new Int(), null];
+		BaseType? value = operands[0];
+		BaseType? nothing = operands[1];
+
+		Assert.IsFalse(value == nothing);
+		Assert.IsTrue(value != nothing);
+		Assert.IsFalse(nothing == value);
+		Assert.IsTrue(nothing != value);
+		Assert.IsTrue(nothing == operands[1]);
+	}
+
+	[TestMethod]
+	public void TestEqualsObjectOverload()
+	{
+		object?[] operands = [new Int(), new String(), null, "Int"];
+		Int a = new();
+
+		Assert.IsTrue(a.Equals(operands[0]));
+		Assert.IsFalse(a.Equals(operands[1]));
+		Assert.IsFalse(a.Equals(operands[2]));
+		Assert.IsFalse(a.Equals(operands[3]));
 	}
 
 	[TestMethod]

--- a/Schema/Models/Schema.Validation.cs
+++ b/Schema/Models/Schema.Validation.cs
@@ -54,15 +54,54 @@ public partial class Schema
 		}
 	}
 
+	/// <summary>
+	/// Renders a name for use in an issue path, standing in for a name that is empty.
+	/// </summary>
+	private static string PathSegment(string name) => string.IsNullOrEmpty(name) ? "(unnamed)" : name;
+
+	/// <summary>
+	/// Reports an element whose name is empty. Such an element cannot be code-generated, and
+	/// duplicate detection only catches multiple empty names by accident.
+	/// </summary>
+	private static void ValidateNameNotEmpty(Collection<SchemaValidationIssue> issues, string name, string kind, string path)
+	{
+		if (string.IsNullOrEmpty(name))
+		{
+			issues.Add(new()
+			{
+				Severity = SchemaValidationSeverity.Error,
+				Path = path,
+				Message = $"{kind} has an empty name.",
+			});
+		}
+	}
+
 	private void ValidateClasses(Collection<SchemaValidationIssue> issues)
 	{
 		foreach (SchemaClass schemaClass in ClassesInternal)
 		{
+			string classPath = PathSegment(schemaClass.Name);
+			ValidateNameNotEmpty(issues, schemaClass.Name, "Class", classPath);
+
 			ReportDuplicates(issues, schemaClass.Members.Select(m => $"{schemaClass.Name}.{m.Name}"), "member");
 
 			foreach (SchemaMember member in schemaClass.Members)
 			{
-				ValidateType(issues, member.Type, $"{schemaClass.Name}.{member.Name}");
+				string memberPath = $"{classPath}.{PathSegment(member.Name)}";
+				ValidateNameNotEmpty(issues, member.Name, "Member", memberPath);
+
+				if (member.Type is None)
+				{
+					// A valid intermediate editing state, but not a generatable schema.
+					issues.Add(new()
+					{
+						Severity = SchemaValidationSeverity.Warning,
+						Path = memberPath,
+						Message = "Member does not have a type set.",
+					});
+				}
+
+				ValidateType(issues, member.Type, memberPath);
 			}
 		}
 	}
@@ -71,7 +110,15 @@ public partial class Schema
 	{
 		foreach (SchemaEnum schemaEnum in EnumsInternal)
 		{
+			string enumPath = PathSegment(schemaEnum.Name);
+			ValidateNameNotEmpty(issues, schemaEnum.Name, "Enum", enumPath);
+
 			ReportDuplicates(issues, schemaEnum.Values.Select(v => $"{schemaEnum.Name}.{v}"), "enum value");
+
+			foreach (Names.EnumValueName value in schemaEnum.Values)
+			{
+				ValidateNameNotEmpty(issues, value, "Enum value", $"{enumPath}.{PathSegment(value)}");
+			}
 		}
 	}
 
@@ -143,6 +190,7 @@ public partial class Schema
 	private void ValidateArray(Collection<SchemaValidationIssue> issues, Array arrayType, string path)
 	{
 		ValidateType(issues, arrayType.ElementType, path);
+		ValidateArrayContainer(issues, arrayType, path);
 
 		if (string.IsNullOrEmpty(arrayType.Key))
 		{
@@ -182,6 +230,42 @@ public partial class Schema
 				Severity = SchemaValidationSeverity.Error,
 				Path = path,
 				Message = $"Array key '{arrayType.Key}' on class '{elementClass.Name}' must be a primitive type but is '{keyMember.Type.DisplayName}'.",
+			});
+		}
+	}
+
+	private static void ValidateArrayContainer(Collection<SchemaValidationIssue> issues, Array arrayType, string path)
+	{
+		if (string.IsNullOrEmpty(arrayType.Container))
+		{
+			// Array.IsKeyed requires a container, and a generator has nothing to map without one.
+			issues.Add(new()
+			{
+				Severity = SchemaValidationSeverity.Warning,
+				Path = path,
+				Message = "Array does not specify a container.",
+			});
+			return;
+		}
+
+		if (!Array.KnownContainers.Contains(arrayType.Container.ToString()))
+		{
+			issues.Add(new()
+			{
+				Severity = SchemaValidationSeverity.Warning,
+				Path = path,
+				Message = $"Array specifies container '{arrayType.Container}', which is not one of the containers this library understands ({string.Join(", ", Array.KnownContainers)}).",
+			});
+			return;
+		}
+
+		if (arrayType.Container.ToString() == Array.MapContainer && string.IsNullOrEmpty(arrayType.Key))
+		{
+			issues.Add(new()
+			{
+				Severity = SchemaValidationSeverity.Error,
+				Path = path,
+				Message = $"Array uses the '{Array.MapContainer}' container but does not specify a key to map by.",
 			});
 		}
 	}

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -500,7 +500,7 @@ public partial class Schema
 		if (type.IsArray)
 		{
 			elementType = type.GetElementType();
-			container = "vector".As<ContainerName>();
+			container = Types.Array.VectorContainer.As<ContainerName>();
 			return elementType is not null;
 		}
 
@@ -508,7 +508,7 @@ public partial class Schema
 		if (dictionaryInterface is not null)
 		{
 			elementType = dictionaryInterface.GetGenericArguments()[1];
-			container = "map".As<ContainerName>();
+			container = Types.Array.MapContainer.As<ContainerName>();
 			return true;
 		}
 
@@ -516,7 +516,7 @@ public partial class Schema
 		if (enumerableInterface is not null)
 		{
 			elementType = enumerableInterface.GetGenericArguments()[0];
-			container = "vector".As<ContainerName>();
+			container = Types.Array.VectorContainer.As<ContainerName>();
 			return true;
 		}
 

--- a/Schema/Models/SchemaMember.cs
+++ b/Schema/Models/SchemaMember.cs
@@ -2,6 +2,7 @@
 
 namespace ktsu.Schema.Models;
 
+using System.Text.Json.Serialization;
 using ktsu.Schema.Models.Names;
 using ktsu.Schema.Models.Types;
 
@@ -13,6 +14,12 @@ public class SchemaMember : SchemaClassChild<MemberName>
 	/// <summary>
 	/// Gets the type of the schema member.
 	/// </summary>
+	/// <remarks>
+	/// <see cref="JsonIncludeAttribute"/> is required because the setter is private: without it
+	/// System.Text.Json writes the type on save but silently ignores it on load, so every member
+	/// in a loaded schema came back as <see cref="None"/>.
+	/// </remarks>
+	[JsonInclude]
 	public BaseType Type { get; private set; } = new None();
 
 	/// <summary>

--- a/Schema/Models/Types/Array.cs
+++ b/Schema/Models/Types/Array.cs
@@ -76,6 +76,8 @@ public class Array : BaseType
 			&& string.Equals(Key, otherArray.Key, StringComparison.Ordinal);
 
 	/// <inheritdoc />
-	public override int GetHashCode() =>
-		HashCode.Combine(GetType(), ElementType, Container.ToString(), Key.ToString());
+	protected override int GetHashCodeCore() => HashCode.Combine(
+		ElementType,
+		StringComparer.Ordinal.GetHashCode(Container.ToString()),
+		StringComparer.Ordinal.GetHashCode(Key.ToString()));
 }

--- a/Schema/Models/Types/Array.cs
+++ b/Schema/Models/Types/Array.cs
@@ -11,7 +11,28 @@ using ktsu.Schema.Models.Names;
 public class Array : BaseType
 {
 	/// <summary>
-	/// Gets or sets the element type of the array.
+	/// The container name for an ordered sequence, mapped to a list by a code generator.
+	/// </summary>
+	public const string VectorContainer = "vector";
+
+	/// <summary>
+	/// The container name for a lookup keyed by <see cref="Key"/>, mapped to a dictionary by a
+	/// code generator.
+	/// </summary>
+	public const string MapContainer = "map";
+
+	/// <summary>
+	/// Gets the container names the library itself produces and understands.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="Container"/> is deliberately open-ended - a consumer may use its own container
+	/// vocabulary - so a name outside this set is reported by
+	/// <see cref="Schema.Validate"/> as a warning rather than an error.
+	/// </remarks>
+	public static IReadOnlyCollection<string> KnownContainers { get; } = [VectorContainer, MapContainer];
+
+	/// <summary>
+	/// Gets the element type of the array.
 	/// </summary>
 	public BaseType ElementType { get; init; } = new None();
 

--- a/Schema/Models/Types/Array.cs
+++ b/Schema/Models/Types/Array.cs
@@ -46,4 +46,15 @@ public class Array : BaseType
 
 		return keyMember is not null;
 	}
+
+	/// <inheritdoc />
+	protected override bool EqualsCore(BaseType other) =>
+		other is Array otherArray
+			&& ElementType.Equals(otherArray.ElementType)
+			&& string.Equals(Container, otherArray.Container, StringComparison.Ordinal)
+			&& string.Equals(Key, otherArray.Key, StringComparison.Ordinal);
+
+	/// <inheritdoc />
+	public override int GetHashCode() =>
+		HashCode.Combine(GetType(), ElementType, Container.ToString(), Key.ToString());
 }

--- a/Schema/Models/Types/BaseType.cs
+++ b/Schema/Models/Types/BaseType.cs
@@ -43,11 +43,31 @@ public abstract class BaseType : IEquatable<BaseType?>
 	public void AssociateWith(SchemaMember schemaMember) => ParentMember = schemaMember;
 
 	/// <summary>
-	/// Determines whether the specified object is equal to the current object.
+	/// Determines whether the specified type is equal to the current type.
 	/// </summary>
-	/// <param name="other">The object to compare with the current object.</param>
-	/// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
-	public bool Equals(BaseType? other) => ReferenceEquals(this, other) || ((other?.GetType() == GetType()) && (other.ToString() != ToString()));
+	/// <remarks>
+	/// Two types are equal when they are the same CLR type and their type-specific state
+	/// matches. Types that carry no state - the primitives, the vectors and colors - are equal
+	/// to any other instance of the same type; the types that do carry state compare it in
+	/// <see cref="EqualsCore(BaseType)"/>.
+	/// </remarks>
+	/// <param name="other">The type to compare with the current type.</param>
+	/// <returns>True if the specified type is equal to the current type; otherwise, false.</returns>
+	public bool Equals(BaseType? other) =>
+		ReferenceEquals(this, other) || (other is not null && other.GetType() == GetType() && EqualsCore(other));
+
+	/// <summary>
+	/// Compares the type-specific state of two instances that are already known to be of the
+	/// same CLR type.
+	/// </summary>
+	/// <remarks>
+	/// The default implementation returns true, which is correct for every stateless type.
+	/// Derived types that carry state - <see cref="Object"/>, <see cref="Enum"/> and
+	/// <see cref="Array"/> - override this and must keep <see cref="GetHashCode"/> in step.
+	/// </remarks>
+	/// <param name="other">The instance to compare against; guaranteed to be the same CLR type as this one.</param>
+	/// <returns>True if the type-specific state matches; otherwise, false.</returns>
+	protected virtual bool EqualsCore(BaseType other) => true;
 
 	/// <summary>
 	/// Determines whether the specified object is equal to the current object.
@@ -60,7 +80,24 @@ public abstract class BaseType : IEquatable<BaseType?>
 	/// Serves as the default hash function.
 	/// </summary>
 	/// <returns>A hash code for the current object.</returns>
-	public override int GetHashCode() => HashCode.Combine(ToString());
+	public override int GetHashCode() => GetType().GetHashCode();
+
+	/// <summary>
+	/// Determines whether two types are equal.
+	/// </summary>
+	/// <param name="left">The first type to compare.</param>
+	/// <param name="right">The second type to compare.</param>
+	/// <returns>True if the types are equal; otherwise, false.</returns>
+	public static bool operator ==(BaseType? left, BaseType? right) =>
+		left is null ? right is null : left.Equals(right);
+
+	/// <summary>
+	/// Determines whether two types are not equal.
+	/// </summary>
+	/// <param name="left">The first type to compare.</param>
+	/// <param name="right">The second type to compare.</param>
+	/// <returns>True if the types are not equal; otherwise, false.</returns>
+	public static bool operator !=(BaseType? left, BaseType? right) => !(left == right);
 
 	/// <summary>
 	/// Returns a string representation of the type.

--- a/Schema/Models/Types/BaseType.cs
+++ b/Schema/Models/Types/BaseType.cs
@@ -79,8 +79,25 @@ public abstract class BaseType : IEquatable<BaseType?>
 	/// <summary>
 	/// Serves as the default hash function.
 	/// </summary>
+	/// <remarks>
+	/// Mirrors <see cref="Equals(BaseType?)"/>: the CLR type identifies the type, and
+	/// <see cref="GetHashCodeCore"/> contributes whatever state
+	/// <see cref="EqualsCore(BaseType)"/> compares. Derived types override that hook rather
+	/// than this method, so equality and hashing cannot drift apart.
+	/// </remarks>
 	/// <returns>A hash code for the current object.</returns>
-	public override int GetHashCode() => GetType().GetHashCode();
+	public override int GetHashCode() => HashCode.Combine(GetType(), GetHashCodeCore());
+
+	/// <summary>
+	/// Contributes the type-specific state to the hash code.
+	/// </summary>
+	/// <remarks>
+	/// The default returns a constant, which is correct for every stateless type. A derived
+	/// type that overrides <see cref="EqualsCore(BaseType)"/> must override this too, hashing
+	/// exactly the state that method compares.
+	/// </remarks>
+	/// <returns>A hash of the type-specific state.</returns>
+	protected virtual int GetHashCodeCore() => 0;
 
 	/// <summary>
 	/// Determines whether two types are equal.

--- a/Schema/Models/Types/Enum.cs
+++ b/Schema/Models/Types/Enum.cs
@@ -15,4 +15,11 @@ public class Enum : BaseType
 	/// Gets or sets the name of the enumeration.
 	/// </summary>
 	public EnumName EnumName { get; init; } = new();
+
+	/// <inheritdoc />
+	protected override bool EqualsCore(BaseType other) =>
+		other is Enum otherEnum && string.Equals(EnumName, otherEnum.EnumName, StringComparison.Ordinal);
+
+	/// <inheritdoc />
+	public override int GetHashCode() => HashCode.Combine(GetType(), EnumName.ToString());
 }

--- a/Schema/Models/Types/Enum.cs
+++ b/Schema/Models/Types/Enum.cs
@@ -21,5 +21,5 @@ public class Enum : BaseType
 		other is Enum otherEnum && string.Equals(EnumName, otherEnum.EnumName, StringComparison.Ordinal);
 
 	/// <inheritdoc />
-	public override int GetHashCode() => HashCode.Combine(GetType(), EnumName.ToString());
+	protected override int GetHashCodeCore() => StringComparer.Ordinal.GetHashCode(EnumName.ToString());
 }

--- a/Schema/Models/Types/Object.cs
+++ b/Schema/Models/Types/Object.cs
@@ -42,4 +42,11 @@ public class Object : BaseType
 	/// </summary>
 	/// <returns>The class name.</returns>
 	public override string ToString() => ClassName;
+
+	/// <inheritdoc />
+	protected override bool EqualsCore(BaseType other) =>
+		other is Object otherObject && string.Equals(ClassName, otherObject.ClassName, StringComparison.Ordinal);
+
+	/// <inheritdoc />
+	public override int GetHashCode() => HashCode.Combine(GetType(), ClassName.ToString());
 }

--- a/Schema/Models/Types/Object.cs
+++ b/Schema/Models/Types/Object.cs
@@ -48,5 +48,5 @@ public class Object : BaseType
 		other is Object otherObject && string.Equals(ClassName, otherObject.ClassName, StringComparison.Ordinal);
 
 	/// <inheritdoc />
-	public override int GetHashCode() => HashCode.Combine(GetType(), ClassName.ToString());
+	protected override int GetHashCodeCore() => StringComparer.Ordinal.GetHashCode(ClassName.ToString());
 }

--- a/Schema/Models/Types/SystemObject.cs
+++ b/Schema/Models/Types/SystemObject.cs
@@ -3,6 +3,13 @@
 namespace ktsu.Schema.Models.Types;
 
 /// <summary>
-/// Represents a system object type.
+/// Represents a built-in structured type supplied by the schema library itself, such as a
+/// vector or a color.
 /// </summary>
-public class SystemObject : Object { }
+/// <remarks>
+/// A system object is structured, but unlike <see cref="Object"/> it does not reference a
+/// user-defined <see cref="SchemaClass"/>: its shape is fixed and known to the library. It is
+/// therefore rooted at <see cref="BaseType"/> rather than at <see cref="Object"/>, which keeps
+/// <see cref="BaseType.IsObject"/> meaning "references a user-defined class".
+/// </remarks>
+public abstract class SystemObject : BaseType { }

--- a/Schema/Models/Types/Vector.cs
+++ b/Schema/Models/Types/Vector.cs
@@ -5,4 +5,4 @@ namespace ktsu.Schema.Models.Types;
 /// <summary>
 /// Represents a vector type.
 /// </summary>
-public class Vector : SystemObject { }
+public abstract class Vector : SystemObject { }

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -250,10 +250,7 @@ public class SchemaEditor
 			string schemaFilePath = CurrentSchemaPath;
 			if (ImGui.MenuItem("Open Externally", !string.IsNullOrEmpty(schemaFilePath)))
 			{
-				using Process p = new();
-				p.StartInfo.FileName = $"explorer.exe";
-				p.StartInfo.Arguments = schemaFilePath;
-				p.Start();
+				OpenExternally(schemaFilePath);
 			}
 
 			ImGui.EndMenu();
@@ -272,6 +269,34 @@ public class SchemaEditor
 			}
 
 			ImGui.EndMenu();
+		}
+	}
+
+	/// <summary>
+	/// Opens a path with the operating system's default handler for it.
+	/// </summary>
+	/// <remarks>
+	/// Delegates to the platform shell rather than naming an executable: "explorer.exe" does
+	/// not exist on Linux or macOS, so the menu item used to take the editor down with an
+	/// unhandled Win32Exception there. Process.Start can still fail on any platform - no shell
+	/// association, a file that has since been removed - so failures are surfaced as a popup.
+	/// </remarks>
+	/// <param name="path">The path to open.</param>
+	private void OpenExternally(string path)
+	{
+		try
+		{
+			using Process process = new();
+			process.StartInfo.FileName = path;
+			process.StartInfo.UseShellExecute = true;
+			process.Start();
+		}
+		catch (Exception ex) when (ex is System.ComponentModel.Win32Exception
+			or ObjectDisposedException
+			or InvalidOperationException
+			or PlatformNotSupportedException)
+		{
+			Popups.OpenMessageOK("Error", $"Failed to open '{path}' externally.\n\n{ex.Message}");
 		}
 	}
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -16,7 +16,7 @@ Current state of the project and planned work.
 
 | Component | Requirement                                          |
 | --------- | ---------------------------------------------------- |
-| .NET SDK  | 10.0 (see `global.json`; the library multi-targets net7.0–net10.0) |
+| .NET SDK  | 10.0.400 or newer (see `global.json`; the library multi-targets net8.0–net10.0) |
 | IDE       | Visual Studio 2022 or VS Code                        |
 | Git       | Latest version                                       |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,7 @@ This guide will help you get up and running with the Schema library quickly.
 
 ### Prerequisites
 
--   .NET 7.0, 8.0, 9.0, or 10.0
+-   .NET 8.0, 9.0, or 10.0
 -   Visual Studio 2022 or Visual Studio Code (recommended)
 
 ### Adding the Library

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.400",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Works through the build blocker, all four `bug`-labelled issues, and the two enhancements that depend on them. The larger editor and code-generation issues (#110, #112–#122) are untouched and want their own PRs.

## #123 — build fails on any SDK that satisfies `global.json`

Reproduced exactly as filed: on SDK 10.0.111 every build failed with `CS9057` before compiling a line, because `ktsu.Sdk` 2.28.0's analyzers reference Roslyn 5.9.

The band-to-Roslyn mapping, read from `dotnet/sdk` release branches (`eng/Version.Details.xml`):

| SDK band | Roslyn |
| --- | --- |
| 10.0.1xx | 5.0.0 |
| 10.0.2xx | 5.3.0 |
| 10.0.3xx | 5.6.0 |
| **10.0.4xx** | **5.9.0** |

So the `global.json` floor moves to `10.0.400`, which is what CI already resolves `10.0.x` to. Anyone on an older 10.0.x now gets an actionable "SDK not found" instead of a compiler error mid-build. The requirement is documented in the README's Building section.

## #106 — `BaseType.Equals` was inverted

The final comparison was `!=` where it meant `==`, so distinct instances of the same type compared unequal while `Object("A")` and `Object("B")` compared *equal* — and `GetHashCode()` hashed `ToString()`, breaking the equality/hash contract.

Equality is now structural per derived type through a `protected virtual bool EqualsCore(BaseType)` hook: `Object` compares `ClassName`, `Enum` compares `EnumName`, `Array` compares element type, container and key. Hashing has the matching shape — `BaseType.GetHashCode` combines the CLR type with a `protected virtual GetHashCodeCore` that derived types override alongside `EqualsCore` — so equality and hashing cannot drift apart. `==` / `!=` operators are added.

The three existing equality tests only exercised the `ReferenceEquals` short-circuit or two different CLR types, so they are strengthened rather than merely kept passing: distinct-instance equality, per-type structural comparison, `HashSet` dedupe, the operators, and the `object` overload.

## #107 — vector and color types inherited `Object`

`Vector2/3/4` and `ColorRGB/RGBA` derived from `Object`, inheriting an always-empty `ClassName`. That made `Validate()` reject every schema using them, left `DisplayName` blank in the editor's type picker, and wrote a meaningless `"className": ""` into every schema file.

`SystemObject` is now rooted at `BaseType`, and both it and `Vector` are `abstract` — neither is registered as a `[JsonDerivedType]`, so an instance of either could never have serialized. `IsObject` now means "references a user-defined class", which is what `Schema.Validation` and `Array.IsKeyed` already assumed.

The `TypeSystemTests` assertions that encoded the old classification are updated, as the issue called for.

## #108 — "Open Externally" hardcoded `explorer.exe`

The menu item threw an unhandled `Win32Exception` on Linux and macOS and took the editor down with it. It now hands the path to the platform shell via `UseShellExecute`, with launch failures surfaced as a message popup. Verified against the real failure path — the dev container has no `xdg-open`, and the thrown `Win32Exception` is caught by the filter rather than escaping.

## #109 — test suite ran against one of three published frameworks

`Schema.Test` now multi-targets `net10.0;net9.0;net8.0`.

Worth flagging: `ktsu.Sdk` pins test projects to a single framework and does it from `Sdk.targets`, which is imported after the project body — so editing `TargetFrameworks` in the csproj alone is silently stomped. The project takes the last word via explicit `Sdk.props` / `Sdk.targets` imports, which is a little unusual and is commented in place. **This arguably belongs upstream in `ktsu.Sdk`**; if you'd rather it live there, this part is easy to drop.

CI also installs the 8.0 and 9.0 runtimes so each test host can start. The documented framework list drops .NET 7.0, which no project in the solution has ever targeted.

## #111 — validation coverage

`Validate()` now reports: empty class / enum / member / enum-value names (error), a member still typed `None` (warning), an array with no container (warning), an array whose container is outside the known vocabulary (warning), and a `map` container with no key to map by (error).

The container vocabulary was two string literals buried in `TryGetCollectionElementType`; it is now named on `Array` as `VectorContainer`, `MapContainer` and `KnownContainers`, used by both the reflection importer and the validator. `Container` stays deliberately open-ended, so an unrecognized name is a warning rather than an error.

Empty enum values can't be produced through `TryAddValue` (it rejects them), so that rule is tested through deserialization — the path a hand-edited schema file actually takes.

## Also: member types were silently dropped on load

Not a filed issue — the new round-trip assertions exposed it. `SchemaMember.Type` has a private setter and lacked `[JsonInclude]`, so `System.Text.Json` wrote it on save and **ignored it on load**. Every member of every loaded schema came back as `None`, which means saved `.schema.json` files were effectively losing all type information.

The existing round-trip tests only counted members and never checked their types, which is why this survived. `[JsonInclude]` is added (matching the pattern already used for the model's collections), and `TestRoundtripWithAllTypes` now asserts that each of the 14 built-in types survives the round trip.

## Verification

173 tests pass on all three target frameworks (146 before this branch). CI is green, including SonarCloud's quality gate — 92.3% coverage on new code, 0 security hotspots, 0% duplication.

One caveat on how this was checked locally: the dev container has SDK 10.0.111 and its network policy blocks `builds.dotnet.microsoft.com`, so neither SDK 10.0.400 nor the .NET 8/9 runtimes could be installed there. Local builds used `Microsoft.Net.Compilers.Toolset` 5.9.0 to supply exactly the Roslyn that 10.0.400 ships, and the net8.0/net9.0 suites were run rolled forward onto the .NET 10 runtime. Both shims are local only — nothing in the diff depends on them — and CI has since exercised the real `global.json` floor and the real per-framework runtimes on both ubuntu and windows.

Closes #106, closes #107, closes #108, closes #109, closes #111, closes #123