### PR TITLE
Keep the window title current, and ask before the window closes (#116)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.47" />
     <PackageVersion Include="ktsu.Semantics.Strings" Version="3.2.0" />
     <PackageVersion Include="ktsu.Semantics.Paths" Version="3.2.0" />
-    <PackageVersion Include="ktsu.ImGui.App" Version="3.15.0" />
+    <PackageVersion Include="ktsu.ImGui.App" Version="3.16.0" />
     <PackageVersion Include="ktsu.ImGui.Popups" Version="3.15.0" />
     <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.15.0" />
     <PackageVersion Include="ktsu.ImGuiNodeEditor" Version="3.15.0" />

--- a/SchemaEditor/Program.cs
+++ b/SchemaEditor/Program.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using ktsu.ImGui.App;
+
+/// <summary>
+/// The application entry point.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="SchemaEditor"/> because starting the application is not part of editing
+/// a schema: the configuration names a windowing framework and a delegate type for each callback,
+/// and holding all of that in the editor class counts against its coupling budget without earning
+/// anything. It also keeps the whole of the host's contract with ImGuiApp readable in one place.
+/// </remarks>
+internal static class Program
+{
+	private static void Main(string[] _) =>
+		ImGuiApp.Start(new()
+		{
+			// The startup title only; SchemaEditor keeps it current from there, showing the open
+			// document and whether it has unsaved changes.
+			Title = nameof(SchemaEditor),
+			OnStart = SchemaEditor.OnStart,
+			OnUpdate = SchemaEditor.Instance.OnTick,
+			OnRender = SchemaEditor.Instance.OnRender,
+			OnAppMenu = SchemaEditor.Instance.OnMenu,
+
+			// Refuses a close that would discard unsaved work, so the editor can ask first.
+			OnClosing = SchemaEditor.Instance.ShouldClose,
+		});
+}

--- a/SchemaEditor/SchemaEditor.Files.cs
+++ b/SchemaEditor/SchemaEditor.Files.cs
@@ -42,11 +42,9 @@ public partial class SchemaEditor
 	/// of the application menu bar.
 	/// </summary>
 	/// <remarks>
-	/// This is where the window title would normally carry the document name and a dirty marker.
-	/// <c>ImGuiAppConfig.Title</c> is init-only and ImGuiApp reads it once when it creates the
-	/// window, and the window itself is internal to that package, so the title cannot be changed
-	/// after startup from here. The menu bar is always visible, so the same information lives
-	/// there instead.
+	/// The window title carries the same information (see <see cref="UpdateWindowTitle"/>). This is
+	/// kept as well as, not instead of: a maximised window's title bar is easy to overlook, and on a
+	/// tiling window manager it may not be drawn at all.
 	/// </remarks>
 	private void ShowDocumentStatus()
 	{
@@ -101,7 +99,11 @@ public partial class SchemaEditor
 	/// unsaved changes.
 	/// </summary>
 	/// <param name="proceed">What to do once it is safe to discard the document.</param>
-	private void WithUnsavedChangesGuard(Action proceed)
+	/// <param name="onCancel">
+	/// Run if the user backs out. Only the close path needs this, to release the latch that stops a
+	/// second prompt stacking on the first; New and Open simply do nothing.
+	/// </param>
+	private void WithUnsavedChangesGuard(Action proceed, Action? onCancel = null)
 	{
 		if (!HasUnsavedChanges)
 		{
@@ -116,7 +118,7 @@ public partial class SchemaEditor
 			{
 				["Save"] = () => SaveThen(proceed),
 				["Discard"] = proceed,
-				["Cancel"] = null,
+				["Cancel"] = onCancel,
 			});
 	}
 
@@ -224,17 +226,83 @@ public partial class SchemaEditor
 		return true;
 	}
 
+	/// <summary>Set once the user has agreed to exit, so the confirmed exit is not vetoed again.</summary>
+	private bool exitConfirmed;
+
+	/// <summary>Set by <see cref="ShouldClose"/> so the prompt is raised from the render loop.</summary>
+	private bool closeRequested;
+
+	/// <summary>Set while the close prompt is on screen, so a second close cannot stack another.</summary>
+	private bool closePromptShowing;
+
 	/// <summary>
-	/// Quits, asking about unsaved changes first.
+	/// Consulted by ImGuiApp before the window closes; returning false keeps the application running.
 	/// </summary>
 	/// <remarks>
-	/// ImGuiApp exposes no cancellable close hook, so clicking the window's own close button
-	/// cannot be intercepted from here. This menu item is the route out that can ask first.
+	/// <para>
+	/// The prompt cannot be drawn from here - this returns before the next frame is rendered - so a
+	/// close with unsaved work only records the request and refuses. <see cref="ProcessCloseRequest"/>
+	/// raises the prompt on the next frame, and <see cref="ConfirmExit"/> closes for real.
+	/// </para>
+	/// <para>
+	/// This also fires for <see cref="ImGuiApp.Stop"/>, which is how the confirmed exit closes, so
+	/// without <see cref="exitConfirmed"/> the application would veto its own agreed exit forever:
+	/// discarding does not clear the unsaved flag, so the condition that refused the first close is
+	/// still true when the user has said to close anyway.
+	/// </para>
 	/// </remarks>
-	private void ExitWithUnsavedChangesGuard() =>
-		WithUnsavedChangesGuard(() =>
+	/// <returns>True to let the close proceed; false to cancel it.</returns>
+	internal bool ShouldClose()
+	{
+		if (exitConfirmed || !HasUnsavedChanges)
 		{
 			SaveOptionsInternal();
-			ImGuiApp.Stop();
-		});
+			return true;
+		}
+
+		closeRequested = true;
+		return false;
+	}
+
+	/// <summary>
+	/// Raises the unsaved-changes prompt for a close that <see cref="ShouldClose"/> refused.
+	/// </summary>
+	private void ProcessCloseRequest()
+	{
+		if (!closeRequested || closePromptShowing)
+		{
+			return;
+		}
+
+		closeRequested = false;
+		closePromptShowing = true;
+		WithUnsavedChangesGuard(ConfirmExit, () => closePromptShowing = false);
+	}
+
+	/// <summary>
+	/// Closes for real, once there is nothing left to ask about.
+	/// </summary>
+	private void ConfirmExit()
+	{
+		exitConfirmed = true;
+		SaveOptionsInternal();
+		ImGuiApp.Stop();
+	}
+
+	/// <summary>
+	/// Quits from the File menu, asking about unsaved changes first.
+	/// </summary>
+	private void ExitWithUnsavedChangesGuard() => WithUnsavedChangesGuard(ConfirmExit);
+
+	/// <summary>
+	/// Keeps the window title showing the open document and whether it has unsaved changes.
+	/// </summary>
+	/// <remarks>
+	/// Called every frame. <c>SetWindowTitle</c> skips the write when the title is unchanged, so
+	/// this costs a string comparison per frame rather than a window call.
+	/// </remarks>
+	private void UpdateWindowTitle() =>
+		ImGuiApp.SetWindowTitle(CurrentSchema is null
+			? nameof(SchemaEditor)
+			: $"{DocumentName}{(HasUnsavedChanges ? "*" : string.Empty)} - {nameof(SchemaEditor)}");
 }

--- a/SchemaEditor/SchemaEditor.Files.cs
+++ b/SchemaEditor/SchemaEditor.Files.cs
@@ -301,8 +301,15 @@ public partial class SchemaEditor
 	/// Called every frame. <c>SetWindowTitle</c> skips the write when the title is unchanged, so
 	/// this costs a string comparison per frame rather than a window call.
 	/// </remarks>
-	private void UpdateWindowTitle() =>
-		ImGuiApp.SetWindowTitle(CurrentSchema is null
-			? nameof(SchemaEditor)
-			: $"{DocumentName}{(HasUnsavedChanges ? "*" : string.Empty)} - {nameof(SchemaEditor)}");
+	private void UpdateWindowTitle()
+	{
+		if (CurrentSchema is null)
+		{
+			ImGuiApp.SetWindowTitle(nameof(SchemaEditor));
+			return;
+		}
+
+		string unsavedMarker = HasUnsavedChanges ? "*" : string.Empty;
+		ImGuiApp.SetWindowTitle($"{DocumentName}{unsavedMarker} - {nameof(SchemaEditor)}");
+	}
 }

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 
 using Hexa.NET.ImGui;
 
-using ktsu.ImGui.App;
 using ktsu.ImGui.Styler;
 using ktsu.ImGui.Widgets;
 using ktsu.IntervalAction;
@@ -46,21 +45,6 @@ public partial class SchemaEditor
 
 	// Tab content delegates are parameterless, so the current frame's delta is stashed here for them.
 	private float currentDeltaTime;
-
-	private static void Main(string[] _)
-	{
-		// ImGuiAppConfig.Title is init-only and ImGuiApp reads it once, when it creates the
-		// window, so this is the only chance to set it. The open document and its unsaved state
-		// are shown in the menu bar instead - see ShowDocumentStatus.
-		ImGuiApp.Start(new()
-		{
-			Title = nameof(SchemaEditor),
-			OnStart = OnStart,
-			OnUpdate = Instance.OnTick,
-			OnRender = Instance.OnRender,
-			OnAppMenu = Instance.OnMenu
-		});
-	}
 
 	public SchemaEditor()
 	{
@@ -119,7 +103,7 @@ public partial class SchemaEditor
 		}
 	}
 
-	private static void OnStart()
+	internal static void OnStart()
 	{
 		// Set up initial window state if needed
 		// Note: Window state handling may need to be implemented differently
@@ -175,10 +159,12 @@ public partial class SchemaEditor
 		RequestValidation();
 	}
 
-	private void OnTick(float dt)
+	internal void OnTick(float dt)
 	{
 		ProcessKeyboardShortcuts();
 		UpdateValidation(dt);
+		UpdateWindowTitle();
+		ProcessCloseRequest();
 	}
 
 	private void ProcessKeyboardShortcuts()
@@ -225,7 +211,7 @@ public partial class SchemaEditor
 		}
 	}
 
-	private void OnRender(float dt)
+	internal void OnRender(float dt)
 	{
 		// Stashed for the parameterless tab content delegates (the Class Graph needs the frame delta).
 		currentDeltaTime = dt;
@@ -263,7 +249,7 @@ public partial class SchemaEditor
 		}
 	}
 
-	private void OnMenu()
+	internal void OnMenu()
 	{
 		ShowFileMenu();
 		ShowEditMenu();


### PR DESCRIPTION
Finishes #116. The last two acceptance criteria were blocked by `ktsu.ImGui.App` — `ImGuiAppConfig.Title` is `init`-only and read once at window creation, and there was no cancellable close hook. I added both upstream in **ktsu-dev/ImGuiApp#341**, now released as **3.16.0**, which this bumps to.

## Live window title

Shows the open document plus a trailing `*` while it has unsaved changes, refreshed each frame. `SetWindowTitle` skips the write when the title is unchanged, so that costs a string comparison per frame rather than a window call.

The dirty state comes from the undo service via the existing `HasUnsavedChanges` — not tracked a second time.

**The menu-bar indicator stays.** It isn't redundant: a maximised window's title bar is easy to overlook, and a tiling window manager may not draw one at all.

## Close prompt

Closing the window now raises the same Save / Discard / Cancel prompt New and Open already use, instead of discarding the work silently.

Three things about the hook are worth a reviewer's attention, because each is a way to get it wrong:

**The prompt can't be drawn from the callback** — it returns before the next frame is rendered. So a close with unsaved work only records the request and refuses; the next frame raises the prompt, and only the user's answer closes for real.

**The callback also fires for `ImGuiApp.Stop`**, which is how the confirmed exit closes. Without the explicit `exitConfirmed` latch the editor would veto its own agreed exit forever — discarding doesn't clear the unsaved flag, so the condition that refused the first close is still true once the user has said to close anyway. That would have been **an unquittable window**, and it's the one bug in this change I'd most want caught.

**A second close while the prompt is up** would otherwise stack another prompt, so the request is latched until the first is answered. `WithUnsavedChangesGuard` grew an optional `onCancel` for that — the close path is the only caller that needs to know the user backed out; New and Open simply do nothing.

## Why the entry point moved

Adding `OnClosing` tipped `SchemaEditor` over the CA1506 class-coupling limit (96, limit 95). I checked what actually cost the point rather than guessing: it's the `Func<bool>` the assignment introduces.

The honest fix was to take out what doesn't belong. `Main` and the `ImGuiAppConfig` now live in `SchemaEditor/Program.cs` — that configuration names a windowing framework and a delegate type per callback, none of which is part of editing a schema. So the fix follows what the analyser was pointing at rather than suppressing it, and the host's whole contract with ImGuiApp is readable in one place. `OnStart`, `OnTick`, `OnRender`, `OnMenu` and `ShouldClose` become `internal` so the entry point can bind them.

## Verification, and its limit

**299 tests pass on net8.0, net9.0 and net10.0**, and the solution builds against 3.16.0 — which is what proves the released package really carries the new API, rather than my assuming it from the merge.

**The editor wiring itself is not covered by any test.** `SchemaEditor` has no tests and no harness to write them against — that's #128. What's verified here is that it compiles and that nothing else regressed; the title updates and the close prompt have not been executed by a test. I'd rather say that plainly than let "299 tests pass" imply more than it does.

That's also the strongest argument yet for #128: this change adds exactly the kind of stateful, sequence-dependent logic (a latch, a deferred prompt, a re-entrancy guard) that a headless harness would catch regressions in. `ktsu.ImGui.App` ships an `ImGui.App.Testing` package built for this.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WmzGm9XniSoqaiVGDT6qT

---
_Generated by [Claude Code](https://claude.ai/code/session_012WmzGm9XniSoqaiVGDT6qT)_