### PR TITLE
Fix the build, and give SchemaEditor a headless test harness (#128)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -364,12 +364,13 @@ jobs:
             '/d:sonar.host.url=https://sonarcloud.io'
             '/d:sonar.projectBaseDir=${{ github.workspace }}'
             '/d:sonar.cs.vscoveragexml.reportsPaths=coverage/**/coverage.xml'
-            # SchemaEditor is excluded from COVERAGE only - it is still analysed for bugs, smells
-            # and security. It is an ImGui application: its code is immediate-mode draw calls that
-            # need a live UI context to execute, so line coverage there cannot be earned without a
-            # UI test harness, tracked separately. Measuring it would only ever report the absence
-            # of a harness. The library, which is what consumers depend on, stays fully measured.
-            '/d:sonar.coverage.exclusions=**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs,SchemaEditor/**/*.cs'
+            # The editor's panel and tree files are excluded from COVERAGE only - they are still
+            # analysed for bugs, smells and security. They are pure immediate-mode draw code:
+            # a Show() method that reads a value, draws a widget and acts on what the widget
+            # reports, with nothing to assert that is not a pixel. SchemaEditor.Test now drives the
+            # rest of the editor headlessly, so the rest is measured; this list is what that
+            # harness does not yet reach, not the whole application.
+            '/d:sonar.coverage.exclusions=**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs,SchemaEditor/ButtonTree.cs,SchemaEditor/ClassGraphView.cs,SchemaEditor/CodeGeneratorPanel.cs,SchemaEditor/SchemaEditor.Panels.cs,SchemaEditor/Tree*.cs'
             '/d:sonar.cs.vstest.reportsPaths=coverage/**/*.trx'
             '/d:sonar.exclusions=**/NativeExports.cs'
           )

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -370,7 +370,10 @@ jobs:
             # reports, with nothing to assert that is not a pixel. SchemaEditor.Test now drives the
             # rest of the editor headlessly, so the rest is measured; this list is what that
             # harness does not yet reach, not the whole application.
-            '/d:sonar.coverage.exclusions=**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs,SchemaEditor/ButtonTree.cs,SchemaEditor/ClassGraphView.cs,SchemaEditor/CodeGeneratorPanel.cs,SchemaEditor/SchemaEditor.Panels.cs,SchemaEditor/Tree*.cs'
+            # SchemaEditor/Program.cs is the one file here excluded because it cannot be executed
+            # rather than because nobody has yet: it holds only Main, which opens a window and does
+            # not return. What the host is configured with lives in EditorHost.cs, which is tested.
+            '/d:sonar.coverage.exclusions=**/*Test*.cs,**/*.Tests.cs,**/*.Tests/**/*,**/obj/**/*,**/*.dll,**/NativeExports.cs,SchemaEditor/Program.cs,SchemaEditor/ButtonTree.cs,SchemaEditor/ClassGraphView.cs,SchemaEditor/CodeGeneratorPanel.cs,SchemaEditor/SchemaEditor.Panels.cs,SchemaEditor/Tree*.cs'
             '/d:sonar.cs.vstest.reportsPaths=coverage/**/*.trx'
             '/d:sonar.exclusions=**/NativeExports.cs'
           )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Schema is a C# library for defining and managing data structure schemas. It consists of four projects:
+Schema is a C# library for defining and managing data structure schemas. It consists of five projects:
 
 - **Schema** - Core library providing schema definition types (classes, enums, members, types)
 - **Schema.Test** - MSTest unit tests for the core library
 - **SchemaEditor** - ImGui-based visual editor application for creating and editing `.schema.json` files
+- **SchemaEditor.Test** - Headless UI tests for the editor, driven through `ktsu.ImGui.App.Testing`
 - **SchemaTool** - Command line entry point for validating schemas and running their code generators
 
 ## Build Commands
@@ -80,6 +81,9 @@ Schema elements maintain parent references via `AssociateWith()` methods. After 
 - `Schema/Models/Types/BaseType.cs` - Abstract base with `[JsonDerivedType]` attributes for polymorphic serialization
 - `Schema/Models/SchemaClass.cs` - Class definitions containing `SchemaMember` collections
 - `SchemaEditor/SchemaEditor.cs` - Main editor application using `ktsu.ImGui.App`
+- `SchemaEditor/Program.cs` - Builds the `ImGuiAppConfig`; `CreateConfig` is what the tests drive too
+- `SchemaEditor.Test/EditorHarness.cs` - Runs a real editor headlessly, frames advanced by the test
+- `SchemaEditor.Test/WidgetHarness.cs` - A headless frame containing only the widget under test
 
 ## Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,8 @@ Schema elements maintain parent references via `AssociateWith()` methods. After 
 - `Schema/Models/Types/BaseType.cs` - Abstract base with `[JsonDerivedType]` attributes for polymorphic serialization
 - `Schema/Models/SchemaClass.cs` - Class definitions containing `SchemaMember` collections
 - `SchemaEditor/SchemaEditor.cs` - Main editor application using `ktsu.ImGui.App`
-- `SchemaEditor/Program.cs` - Builds the `ImGuiAppConfig`; `CreateConfig` is what the tests drive too
+- `SchemaEditor/EditorHost.cs` - Builds the `ImGuiAppConfig`; `CreateConfig` is what the tests drive too
+- `SchemaEditor/Program.cs` - The entry point, and the only file excluded from coverage measurement
 - `SchemaEditor.Test/EditorHarness.cs` - Runs a real editor headlessly, frames advanced by the test
 - `SchemaEditor.Test/WidgetHarness.cs` - A headless frame containing only the widget under test
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="ktsu.Semantics.Strings" Version="3.2.5" />
     <PackageVersion Include="ktsu.Semantics.Paths" Version="3.2.5" />
     <PackageVersion Include="ktsu.ImGui.App" Version="3.16.6" />
+    <PackageVersion Include="ktsu.ImGui.App.Testing" Version="3.16.6" />
     <PackageVersion Include="ktsu.ImGui.Popups" Version="3.16.6" />
     <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.16.6" />
     <PackageVersion Include="ktsu.ImGuiNodeEditor" Version="3.16.6" />
@@ -28,5 +29,6 @@
     <PackageVersion Include="Microsoft.SourceLink.AzureRepos.Git" Version="10.0.400" />
     <PackageVersion Include="Polyfill" Version="11.2.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.11" />
+    <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ A C# library for defining, managing, and editing data structure schemas with a r
 
 **ktsu.Schema** lets you define structured data models programmatically or visually, then serialize them to `.schema.json` files (documented in the [schema file format reference](docs/schema-format.md)). It provides a foundation for code generation, data validation, and tooling that needs to understand your data structures at a metadata level.
 
-The solution contains three projects:
+The solution contains five projects:
 
 - **Schema** - Core library with schema definition types, a rich type system, and JSON serialization
 - **Schema.Test** - Unit tests for the core library
 - **SchemaEditor** - ImGui-based desktop application for visual schema editing
+- **SchemaEditor.Test** - Headless UI tests that drive the editor with no window or display
+- **SchemaTool** - Command line entry point for validating schemas and running their code generators
 
 ## Installation
 

--- a/Schema.sln
+++ b/Schema.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchemaEditor", "SchemaEdito
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchemaTool", "SchemaTool\SchemaTool.csproj", "{1EBD8E07-A2A3-4091-8748-ECFEB1D301F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchemaEditor.Test", "SchemaEditor.Test\SchemaEditor.Test.csproj", "{31DEE39F-3542-4B65-B744-74243D28D878}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,18 @@ Global
 		{1EBD8E07-A2A3-4091-8748-ECFEB1D301F0}.Release|x64.Build.0 = Release|Any CPU
 		{1EBD8E07-A2A3-4091-8748-ECFEB1D301F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{1EBD8E07-A2A3-4091-8748-ECFEB1D301F0}.Release|x86.Build.0 = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|x64.Build.0 = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Debug|x86.Build.0 = Debug|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|x64.ActiveCfg = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|x64.Build.0 = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|x86.ActiveCfg = Release|Any CPU
+		{31DEE39F-3542-4B65-B744-74243D28D878}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Schema/AssemblyInfo.cs
+++ b/Schema/AssemblyInfo.cs
@@ -1,3 +1,8 @@
 // Copyright (c) 2023-2026 ktsu-dev contributors
 
+// Both test assemblies are named, rather than only the one that reads this project's internals.
+// ktsu.Sdk's KTSU0002 requires a non-test project to expose its internals to the repository's test
+// projects, and there are two of them now; which of the two a given project actually needs is not
+// what the rule is checking.
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.Schema.Test")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.SchemaEditor.Test")]

--- a/SchemaEditor.Test/AssemblyInfo.cs
+++ b/SchemaEditor.Test/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+// One ImGui context exists at a time, and ImGuiAppHarness refuses to start a second while one is
+// running, so these tests cannot run concurrently with each other the way the library's can.
+[assembly: DoNotParallelize]

--- a/SchemaEditor.Test/DiagnosticsTests.cs
+++ b/SchemaEditor.Test/DiagnosticsTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System.Linq;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// The diagnostics panel's logic: when validation runs, and what clicking an issue selects.
+/// </summary>
+[TestClass]
+public sealed class DiagnosticsTests
+{
+	private EditorHarness harness = null!;
+
+	[TestInitialize]
+	public void StartEditor() => harness = EditorHarness.Start();
+
+	[TestCleanup]
+	public void StopEditor() => harness.Dispose();
+
+	/// <summary>
+	/// Builds a schema whose every element kind has something wrong with it, so one validation run
+	/// produces an issue pointing at each.
+	/// </summary>
+	private static Schema BuildSchemaWithAnIssuePerElementKind()
+	{
+		Schema schema = new();
+
+		// A member with no type: a warning naming the member.
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		user.AddMember("Untyped".As<MemberName>());
+
+		// An empty class name: an error naming the class.
+		schema.AddClass(new ClassName());
+
+		// An empty enum name: an error naming the enum.
+		schema.AddEnum(new EnumName());
+
+		// A data source with no class and no file: warnings naming the data source.
+		schema.AddDataSource("Users".As<DataSourceName>());
+
+		// A code generator with no output path and no language: warnings naming the generator.
+		schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>());
+
+		return schema;
+	}
+
+	[TestMethod]
+	public void ValidationDoesNotRunUntilTheSchemaSettles()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		harness.Editor.RequestValidation();
+
+		// Just short of the debounce: the edit is still in flight, so nothing has been validated.
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds - 0.01f);
+		Assert.AreEqual(0, harness.Editor.Diagnostics.Count);
+
+		harness.Editor.UpdateValidation(0.02f);
+		Assert.IsTrue(harness.Editor.Diagnostics.Count > 0, "The schema should have been validated once the debounce elapsed.");
+	}
+
+	/// <summary>
+	/// A burst of edits - the case the debounce exists for - must validate once at the end rather
+	/// than once per edit.
+	/// </summary>
+	[TestMethod]
+	public void EachEditRestartsTheDebounce()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+
+		for (int edit = 0; edit < 5; edit++)
+		{
+			harness.Editor.RequestValidation();
+			harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds - 0.01f);
+			Assert.AreEqual(0, harness.Editor.Diagnostics.Count, $"Validation ran while edit {edit} was still in flight.");
+		}
+
+		harness.Editor.UpdateValidation(0.02f);
+		Assert.IsTrue(harness.Editor.Diagnostics.Count > 0);
+	}
+
+	[TestMethod]
+	public void ValidationDoesNotRunAgainUntilSomethingChanges()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+
+		System.Collections.ObjectModel.Collection<SchemaValidationIssue> first = harness.Editor.Diagnostics;
+
+		harness.Editor.UpdateValidation(10f);
+
+		Assert.AreSame(first, harness.Editor.Diagnostics, "Validation re-ran without the schema having changed.");
+	}
+
+	[TestMethod]
+	public void ValidatingWithNoSchemaClearsTheIssues()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+		Assert.IsTrue(harness.Editor.Diagnostics.Count > 0);
+
+		harness.Editor.CurrentSchema = null;
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+
+		Assert.AreEqual(0, harness.Editor.Diagnostics.Count);
+	}
+
+	private SchemaValidationIssue IssueFor<TElement>() =>
+		harness.Editor.Diagnostics.FirstOrDefault(i => i.Element is TElement)
+			?? throw new AssertFailedException($"No validation issue was reported against a {typeof(TElement).Name}. Issues: {string.Join("; ", harness.Editor.Diagnostics.Select(i => $"{i.Path}: {i.Message}"))}");
+
+	private void ValidateOnce()
+	{
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+	}
+
+	[TestMethod]
+	public void NavigatingToAClassIssueSelectsTheClass()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		SchemaValidationIssue issue = IssueFor<SchemaClass>();
+		harness.Editor.NavigateTo(issue);
+
+		Assert.AreSame(issue.Element, harness.Editor.CurrentClass);
+	}
+
+	/// <summary>
+	/// A member has no panel of its own; its row is drawn in its class's, so that is what must be
+	/// selected.
+	/// </summary>
+	[TestMethod]
+	public void NavigatingToAMemberIssueSelectsItsOwningClass()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		SchemaValidationIssue issue = IssueFor<SchemaMember>();
+		harness.Editor.NavigateTo(issue);
+
+		Assert.AreSame(((SchemaMember)issue.Element!).ParentClass, harness.Editor.CurrentClass);
+	}
+
+	[TestMethod]
+	public void NavigatingToAnEnumIssueSelectsTheEnum()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		SchemaValidationIssue issue = IssueFor<SchemaEnum>();
+		harness.Editor.NavigateTo(issue);
+
+		Assert.AreSame(issue.Element, harness.Editor.CurrentEnum);
+	}
+
+	[TestMethod]
+	public void NavigatingToADataSourceIssueSelectsTheDataSource()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		SchemaValidationIssue issue = IssueFor<DataSource>();
+		harness.Editor.NavigateTo(issue);
+
+		Assert.AreSame(issue.Element, harness.Editor.CurrentDataSource);
+	}
+
+	[TestMethod]
+	public void NavigatingToACodeGeneratorIssueSelectsTheCodeGenerator()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		SchemaValidationIssue issue = IssueFor<SchemaCodeGenerator>();
+		harness.Editor.NavigateTo(issue);
+
+		Assert.AreSame(issue.Element, harness.Editor.CurrentCodeGenerator);
+	}
+
+	/// <summary>
+	/// Selecting one element must clear the rest, or two panels would claim to be showing the
+	/// current selection at once.
+	/// </summary>
+	[TestMethod]
+	public void NavigatingClearsThePreviousSelection()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+
+		harness.Editor.NavigateTo(IssueFor<SchemaClass>());
+		harness.Editor.NavigateTo(IssueFor<DataSource>());
+
+		Assert.IsNull(harness.Editor.CurrentClass);
+		Assert.IsNotNull(harness.Editor.CurrentDataSource);
+	}
+
+	/// <summary>
+	/// A duplicate-name issue names no single element, so there is nothing to select and nothing
+	/// should change.
+	/// </summary>
+	[TestMethod]
+	public void NavigatingToAnIssueWithNoElementChangesNothing()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAnIssuePerElementKind();
+		ValidateOnce();
+		harness.Editor.NavigateTo(IssueFor<SchemaClass>());
+		SchemaClass? selected = harness.Editor.CurrentClass;
+
+		harness.Editor.NavigateTo(new SchemaValidationIssue
+		{
+			Severity = SchemaValidationSeverity.Error,
+			Path = "User",
+			Message = "Duplicate class name 'User'.",
+		});
+
+		Assert.AreSame(selected, harness.Editor.CurrentClass);
+	}
+
+	[TestMethod]
+	public void AnElementWithNoIssueIsNotMarked()
+	{
+		Schema schema = new();
+		SchemaClass clean = schema.AddClass("Clean".As<ClassName>())!;
+		harness.Editor.CurrentSchema = schema;
+		ValidateOnce();
+
+		Assert.IsNull(harness.Editor.GetIssueFor(clean));
+	}
+
+	[TestMethod]
+	public void AnElementWithNoElementReferenceIsNotMatched() =>
+		Assert.IsNull(harness.Editor.GetIssueFor(null));
+
+	/// <summary>
+	/// The inline marker has room for one issue, so it must be the most severe one affecting the
+	/// element rather than whichever validation happened to report first.
+	/// </summary>
+	[TestMethod]
+	public void TheMarkerForAnElementIsItsMostSevereIssue()
+	{
+		Schema schema = new();
+
+		// No class and no file: the missing class is a warning, and the missing file is another.
+		// Pointing it at a class that does not exist makes the first an error instead.
+		DataSource dataSource = schema.AddDataSource("Users".As<DataSourceName>())!;
+		dataSource.ClassName = "Missing".As<ClassName>();
+
+		harness.Editor.CurrentSchema = schema;
+		ValidateOnce();
+
+		SchemaValidationIssue? marked = harness.Editor.GetIssueFor(dataSource);
+
+		Assert.IsNotNull(marked);
+		Assert.AreEqual(SchemaValidationSeverity.Error, marked.Severity);
+		Assert.IsTrue(
+			harness.Editor.Diagnostics.Any(i => ReferenceEquals(i.Element, dataSource) && i.Severity == SchemaValidationSeverity.Warning),
+			"This test only proves anything while the data source also has a warning to be outranked.");
+	}
+}

--- a/SchemaEditor.Test/DocumentGuardTests.cs
+++ b/SchemaEditor.Test/DocumentGuardTests.cs
@@ -24,7 +24,7 @@ using ktsu.UndoRedo;
 public sealed class DocumentGuardTests
 {
 	private EditorHarness harness = null!;
-	private string scratchDirectory = null!;
+	private AbsoluteDirectoryPath scratchDirectory = null!;
 
 	[TestInitialize]
 	public void StartEditor()
@@ -32,8 +32,7 @@ public sealed class DocumentGuardTests
 		harness = EditorHarness.Start();
 
 		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
-		string scratchDirectoryName = $"schema-editor-tests-{Guid.NewGuid():N}";
-		scratchDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileName(scratchDirectoryName));
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-editor-tests-{Guid.NewGuid():N}".As<DirectoryName>();
 		Directory.CreateDirectory(scratchDirectory);
 	}
 
@@ -56,14 +55,14 @@ public sealed class DocumentGuardTests
 	/// A path inside this test's scratch directory.
 	/// </summary>
 	/// <remarks>
-	/// The name is reduced to its leaf first. <see cref="Path.Combine(string, string)"/> discards
-	/// everything before a rooted segment, so combining an unreduced name would put the file
-	/// somewhere other than the scratch directory - and so outside what <see cref="StopEditor"/>
-	/// deletes.
+	/// Composed with the '/' operator from ktsu.Semantics.Paths rather than
+	/// <c>Path.Combine</c>, which silently discards everything before a rooted segment - so a
+	/// name that was not a leaf would put the file somewhere other than the scratch directory,
+	/// and so outside what <see cref="StopEditor"/> deletes. A <see cref="FileName"/> cannot be
+	/// rooted, which is what makes the composition safe rather than merely intended to be.
 	/// </remarks>
-	/// <param name="name">The file name, which must be a leaf.</param>
-	private AbsoluteFilePath ScratchFile(string name) =>
-		Path.Combine(scratchDirectory, Path.GetFileName(name)).As<AbsoluteFilePath>();
+	/// <param name="name">The file name.</param>
+	private AbsoluteFilePath ScratchFile(string name) => scratchDirectory / name.As<FileName>();
 
 	/// <summary>
 	/// Opens a document and makes an edit through the undo service, which is what
@@ -206,9 +205,11 @@ public sealed class DocumentGuardTests
 		harness.Editor.CurrentSchema = new Schema();
 
 		// A path whose parent is an existing file rather than a directory cannot be created.
-		AbsoluteFilePath blocker = ScratchFile("blocker");
+		const string blockerName = "blocker";
+		AbsoluteFilePath blocker = ScratchFile(blockerName);
 		File.WriteAllText(blocker, "not a directory");
-		harness.Editor.CurrentSchemaPath = Path.Combine(blocker.ToString(), "nested.schema.json").As<AbsoluteFilePath>();
+		harness.Editor.CurrentSchemaPath =
+			scratchDirectory / blockerName.As<DirectoryName>() / "nested.schema.json".As<FileName>();
 
 		bool proceeded = false;
 		harness.Editor.SaveThen(() => proceeded = true);

--- a/SchemaEditor.Test/DocumentGuardTests.cs
+++ b/SchemaEditor.Test/DocumentGuardTests.cs
@@ -1,0 +1,331 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+/// <summary>
+/// The guard that stands between an action and the open document's unsaved work, and the
+/// save-then-continue sequence it starts.
+/// </summary>
+/// <remarks>
+/// These run through the prompt as a user does - the popup is drawn into a real frame and the
+/// button is clicked by name - because the sequencing being tested is precisely what the popup's
+/// callbacks do, and a test that invoked those callbacks directly would not be testing it.
+/// </remarks>
+[TestClass]
+public sealed class DocumentGuardTests
+{
+	private EditorHarness harness = null!;
+	private string scratchDirectory = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+
+		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
+		scratchDirectory = Path.Combine(Path.GetTempPath(), $"schema-editor-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(scratchDirectory);
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		harness.Dispose();
+
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	private AbsoluteFilePath ScratchFile(string name) =>
+		Path.Combine(scratchDirectory, name).As<AbsoluteFilePath>();
+
+	/// <summary>
+	/// Opens a document and makes an edit through the undo service, which is what
+	/// <see cref="SchemaEditor.HasUnsavedChanges"/> reads.
+	/// </summary>
+	private void OpenDirtyDocument()
+	{
+		Schema schema = new();
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.Execute(new DelegateCommand(
+			"Add Class",
+			() => schema.TryAddClass("User".As<ClassName>()),
+			() => schema.RemoveClass("User".As<ClassName>()),
+			ChangeType.Insert));
+
+		Assert.IsTrue(harness.Editor.HasUnsavedChanges, "The document should be dirty after an edit.");
+	}
+
+	/// <summary>
+	/// Advances frames until the prompt has been drawn, then clicks one of its buttons.
+	/// </summary>
+	/// <remarks>
+	/// The extra frames after the button first appears are not padding. A modal sizes itself from
+	/// its contents on the frame it appears and is centred on the next, so the rectangle recorded
+	/// for a button on its first frame is not where that button ends up. Clicking there hits the
+	/// background instead, and the prompt sits unanswered.
+	/// </remarks>
+	private void AnswerPrompt(string button)
+	{
+		harness.StepUntil(() => harness.App.Probe.Matches(button).Count > 0, $"the '{button}' button appearing");
+		harness.App.Step(3);
+		harness.App.Click(button);
+		harness.App.Step(2);
+	}
+
+	[TestMethod]
+	public void AnUnmodifiedDocumentIsDiscardedWithoutAsking()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		bool proceeded = false;
+
+		harness.Editor.WithUnsavedChangesGuard(() => proceeded = true);
+
+		Assert.IsTrue(proceeded, "Nothing was at risk, so the action should have run straight away.");
+	}
+
+	[TestMethod]
+	public void AModifiedDocumentIsNotDiscardedWithoutAsking()
+	{
+		OpenDirtyDocument();
+		bool proceeded = false;
+
+		harness.Editor.WithUnsavedChangesGuard(() => proceeded = true);
+		harness.App.Step(3);
+
+		Assert.IsFalse(proceeded, "The action ran before the user was asked about unsaved work.");
+		Assert.IsTrue(harness.App.Probe.Matches("Discard").Count > 0, "The unsaved-changes prompt was not raised.");
+	}
+
+	[TestMethod]
+	public void DiscardingRunsTheAction()
+	{
+		OpenDirtyDocument();
+		bool proceeded = false;
+
+		harness.Editor.WithUnsavedChangesGuard(() => proceeded = true);
+		AnswerPrompt("Discard");
+
+		Assert.IsTrue(proceeded);
+	}
+
+	[TestMethod]
+	public void CancellingRunsNeitherTheActionNorNothing()
+	{
+		OpenDirtyDocument();
+		bool proceeded = false;
+		bool cancelled = false;
+
+		harness.Editor.WithUnsavedChangesGuard(() => proceeded = true, () => cancelled = true);
+		AnswerPrompt("Cancel");
+
+		Assert.IsFalse(proceeded);
+		Assert.IsTrue(cancelled);
+	}
+
+	[TestMethod]
+	public void SavingWritesTheDocumentAndThenRunsTheAction()
+	{
+		OpenDirtyDocument();
+		AbsoluteFilePath path = ScratchFile("saved.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+		bool proceeded = false;
+
+		harness.Editor.WithUnsavedChangesGuard(() => proceeded = true);
+		AnswerPrompt("Save");
+
+		Assert.IsTrue(File.Exists(path), "The document should have been written before the action ran.");
+		Assert.IsTrue(proceeded);
+		Assert.IsFalse(harness.Editor.HasUnsavedChanges, "Saving should have cleared the unsaved marker.");
+	}
+
+	/// <summary>
+	/// A document with no path cannot be saved without asking where to put it, and the file browser
+	/// answers over later frames. The continuation must wait for that answer rather than running as
+	/// though the save had happened.
+	/// </summary>
+	[TestMethod]
+	public void SavingADocumentWithNoPathDefersTheActionToTheFileBrowser()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		Assert.AreEqual(string.Empty, harness.Editor.CurrentSchemaPath.ToString());
+		bool proceeded = false;
+
+		harness.Editor.SaveThen(() => proceeded = true);
+		harness.App.Step(3);
+
+		Assert.IsFalse(proceeded, "The action ran without the document having been saved anywhere.");
+	}
+
+	[TestMethod]
+	public void SavingADocumentWithAPathRunsTheActionOnceItIsWritten()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		AbsoluteFilePath path = ScratchFile("direct.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+		bool proceeded = false;
+
+		harness.Editor.SaveThen(() => proceeded = true);
+
+		Assert.IsTrue(File.Exists(path));
+		Assert.IsTrue(proceeded);
+	}
+
+	/// <summary>
+	/// A save that fails must not run the continuation: the work it was guarding is still at risk.
+	/// </summary>
+	[TestMethod]
+	public void AFailedSaveDoesNotRunTheAction()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+
+		// A path whose parent is an existing file rather than a directory cannot be created.
+		AbsoluteFilePath blocker = ScratchFile("blocker");
+		File.WriteAllText(blocker, "not a directory");
+		harness.Editor.CurrentSchemaPath = Path.Combine(blocker, "nested.schema.json").As<AbsoluteFilePath>();
+
+		bool proceeded = false;
+		harness.Editor.SaveThen(() => proceeded = true);
+
+		Assert.IsFalse(proceeded);
+	}
+
+	[TestMethod]
+	public void SavingRecordsTheDocumentAsRecentlyUsed()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		AbsoluteFilePath path = ScratchFile("recent.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+
+		harness.Editor.SaveThen(null);
+
+		Assert.AreEqual(path, harness.Editor.Options.RecentFiles[0]);
+	}
+
+	[TestMethod]
+	public void OpeningADocumentRecordsItAsRecentlyUsedAndSelectsItsFirstClass()
+	{
+		Schema source = new();
+		source.AddClass("First".As<ClassName>());
+		source.AddClass("Second".As<ClassName>());
+		AbsoluteFilePath path = ScratchFile("opened.schema.json");
+		File.WriteAllText(path, SchemaSerializer.Serialize(source));
+
+		harness.Editor.LoadFrom(path);
+
+		Assert.IsNotNull(harness.Editor.CurrentSchema);
+		Assert.AreEqual(path, harness.Editor.CurrentSchemaPath);
+		Assert.AreEqual("First", harness.Editor.CurrentClass?.Name.ToString());
+		Assert.AreEqual(path, harness.Editor.Options.RecentFiles[0]);
+		Assert.AreEqual("opened.schema.json", harness.Editor.DocumentName);
+	}
+
+	/// <summary>
+	/// A failed open must leave the document that is already open alone, rather than half-replacing
+	/// it with nothing.
+	/// </summary>
+	[TestMethod]
+	public void AFailedOpenLeavesTheCurrentDocumentAlone()
+	{
+		Schema open = new();
+		harness.Editor.CurrentSchema = open;
+		AbsoluteFilePath path = ScratchFile("kept.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+
+		harness.Editor.LoadFrom(ScratchFile("missing.schema.json"));
+
+		Assert.AreSame(open, harness.Editor.CurrentSchema);
+		Assert.AreEqual(path, harness.Editor.CurrentSchemaPath);
+	}
+
+	[TestMethod]
+	public void ANewDocumentReplacesAnUnmodifiedOne()
+	{
+		Schema first = new();
+		harness.Editor.CurrentSchema = first;
+
+		harness.Editor.New();
+
+		Assert.IsNotNull(harness.Editor.CurrentSchema);
+		Assert.AreNotSame(first, harness.Editor.CurrentSchema);
+		Assert.AreEqual(string.Empty, harness.Editor.CurrentSchemaPath.ToString());
+	}
+
+	[TestMethod]
+	public void ANewDocumentAsksBeforeReplacingAModifiedOne()
+	{
+		OpenDirtyDocument();
+		Schema dirty = harness.Editor.CurrentSchema!;
+
+		harness.Editor.New();
+		harness.App.Step(3);
+
+		Assert.AreSame(dirty, harness.Editor.CurrentSchema);
+
+		AnswerPrompt("Discard");
+
+		Assert.AreNotSame(dirty, harness.Editor.CurrentSchema);
+	}
+
+	[TestMethod]
+	public void ClosingIsAllowedWhenNothingWouldBeLost()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+
+		Assert.IsTrue(harness.Editor.ShouldClose());
+	}
+
+	[TestMethod]
+	public void ClosingIsRefusedWhileWorkWouldBeLost()
+	{
+		OpenDirtyDocument();
+
+		Assert.IsFalse(harness.Editor.ShouldClose());
+	}
+
+	/// <summary>
+	/// The refused close has to raise its prompt from the render loop, since the close callback
+	/// returns before another frame is drawn.
+	/// </summary>
+	[TestMethod]
+	public void ARefusedCloseRaisesThePromptOnALaterFrame()
+	{
+		OpenDirtyDocument();
+
+		Assert.IsFalse(harness.Editor.ShouldClose());
+		harness.StepUntil(() => harness.App.Probe.Matches("Discard").Count > 0, "the close prompt appearing");
+	}
+
+	/// <summary>
+	/// Hitting the close button repeatedly must not stack a prompt per press, which would leave the
+	/// user dismissing the same question several times.
+	/// </summary>
+	[TestMethod]
+	public void RepeatedCloseAttemptsRaiseOnlyOnePrompt()
+	{
+		OpenDirtyDocument();
+
+		Assert.IsFalse(harness.Editor.ShouldClose());
+		Assert.IsFalse(harness.Editor.ShouldClose());
+		harness.App.Step(3);
+		harness.Editor.ProcessCloseRequest();
+		harness.App.Step(3);
+
+		Assert.IsFalse(harness.App.Probe.IsAmbiguous("Discard"), "More than one unsaved-changes prompt was raised.");
+	}
+}

--- a/SchemaEditor.Test/DocumentGuardTests.cs
+++ b/SchemaEditor.Test/DocumentGuardTests.cs
@@ -32,7 +32,8 @@ public sealed class DocumentGuardTests
 		harness = EditorHarness.Start();
 
 		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
-		scratchDirectory = Path.Combine(Path.GetTempPath(), $"schema-editor-tests-{Guid.NewGuid():N}");
+		string scratchDirectoryName = $"schema-editor-tests-{Guid.NewGuid():N}";
+		scratchDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileName(scratchDirectoryName));
 		Directory.CreateDirectory(scratchDirectory);
 	}
 
@@ -51,8 +52,18 @@ public sealed class DocumentGuardTests
 		}
 	}
 
+	/// <summary>
+	/// A path inside this test's scratch directory.
+	/// </summary>
+	/// <remarks>
+	/// The name is reduced to its leaf first. <see cref="Path.Combine(string, string)"/> discards
+	/// everything before a rooted segment, so combining an unreduced name would put the file
+	/// somewhere other than the scratch directory - and so outside what <see cref="StopEditor"/>
+	/// deletes.
+	/// </remarks>
+	/// <param name="name">The file name, which must be a leaf.</param>
 	private AbsoluteFilePath ScratchFile(string name) =>
-		Path.Combine(scratchDirectory, name).As<AbsoluteFilePath>();
+		Path.Combine(scratchDirectory, Path.GetFileName(name)).As<AbsoluteFilePath>();
 
 	/// <summary>
 	/// Opens a document and makes an edit through the undo service, which is what
@@ -197,7 +208,7 @@ public sealed class DocumentGuardTests
 		// A path whose parent is an existing file rather than a directory cannot be created.
 		AbsoluteFilePath blocker = ScratchFile("blocker");
 		File.WriteAllText(blocker, "not a directory");
-		harness.Editor.CurrentSchemaPath = Path.Combine(blocker, "nested.schema.json").As<AbsoluteFilePath>();
+		harness.Editor.CurrentSchemaPath = Path.Combine(blocker.ToString(), "nested.schema.json").As<AbsoluteFilePath>();
 
 		bool proceeded = false;
 		harness.Editor.SaveThen(() => proceeded = true);

--- a/SchemaEditor.Test/EditFieldTests.cs
+++ b/SchemaEditor.Test/EditFieldTests.cs
@@ -1,0 +1,262 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.App.Testing;
+
+/// <summary>
+/// That a text field reports one value per editing session rather than one per frame, and that two
+/// fields sharing a label do not share a buffer.
+/// </summary>
+/// <remarks>
+/// This is the widget the editor's every name and description field is built on. ImGui hands back
+/// its buffer on every frame the widget exists, so the naive binding writes to the model sixty
+/// times a second and, now that edits are undoable, pushes an undo entry each time.
+/// </remarks>
+[TestClass]
+public sealed class EditFieldTests
+{
+	private WidgetHarness harness = null!;
+
+	[TestInitialize]
+	public void StartHarness()
+	{
+		harness = WidgetHarness.Start();
+		EditField.Reset();
+	}
+
+	[TestCleanup]
+	public void StopHarness()
+	{
+		EditField.Reset();
+		harness.Dispose();
+	}
+
+	/// <summary>
+	/// One text field, with everything a test needs to drive it and to see what it reported.
+	/// </summary>
+	private sealed class Field
+	{
+		internal string Model { get; set; } = string.Empty;
+		internal string Id { get; init; } = "##Field";
+		internal string? Scope { get; init; }
+		internal int Commits { get; private set; }
+		internal string? LastCommit { get; private set; }
+		internal Vector2 Centre { get; private set; }
+		internal Rectangle Bounds { get; private set; }
+
+		internal void Draw()
+		{
+			if (Scope is not null)
+			{
+				ImGui.PushID(Scope);
+			}
+
+			if (EditField.Text(Id, 200f, Model, out string committed))
+			{
+				Commits++;
+				LastCommit = committed;
+				Model = committed;
+			}
+
+			Vector2 min = ImGui.GetItemRectMin();
+			Vector2 max = ImGui.GetItemRectMax();
+			Centre = (min + max) * 0.5f;
+			Bounds = new Rectangle((int)min.X, (int)min.Y, (int)MathF.Ceiling(max.X), (int)MathF.Ceiling(max.Y));
+
+			if (Scope is not null)
+			{
+				ImGui.PopID();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Clicks into a field and replaces its contents, leaving the field still being edited.
+	/// </summary>
+	private void TypeInto(Field field, string text)
+	{
+		harness.App.Mouse.Click(field.Centre.X, field.Centre.Y);
+		harness.App.Keyboard.Press(ImGuiKey.A, ctrl: true);
+		harness.App.Keyboard.Type(text);
+	}
+
+	private void CommitWithEnter() => harness.App.Keyboard.Press(ImGuiKey.Enter);
+
+	[TestMethod]
+	public void AnUntouchedFieldReportsNothing()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+
+		harness.App.Step(10);
+
+		Assert.AreEqual(0, field.Commits, "A field nobody touched wrote to the model.");
+	}
+
+	[TestMethod]
+	public void FinishingAnEditReportsTheNewValue()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		TypeInto(field, "User");
+		CommitWithEnter();
+
+		Assert.AreEqual(1, field.Commits);
+		Assert.AreEqual("User", field.LastCommit);
+	}
+
+	/// <summary>
+	/// The point of the widget: an editing session is one write, and so one undo entry, however
+	/// many frames it spans.
+	/// </summary>
+	[TestMethod]
+	public void AnEditIsReportedOnceRatherThanPerFrame()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		TypeInto(field, "User");
+		CommitWithEnter();
+		harness.App.Step(30);
+
+		Assert.AreEqual(1, field.Commits, "The field kept writing to the model after the edit finished.");
+	}
+
+	[TestMethod]
+	public void LeavingAFieldWithoutChangingItReportsNothing()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		harness.App.Mouse.Click(field.Centre.X, field.Centre.Y);
+		harness.App.Keyboard.Press(ImGuiKey.Enter);
+		harness.App.Step(3);
+
+		Assert.AreEqual(0, field.Commits);
+		Assert.AreEqual("Name", field.Model);
+	}
+
+	/// <summary>
+	/// Escape abandons the edit, so nothing should reach the model - and no undo entry should be
+	/// pushed for an edit the user took back.
+	/// </summary>
+	[TestMethod]
+	public void AbandoningAnEditReportsNothing()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		TypeInto(field, "User");
+		harness.App.Keyboard.Press(ImGuiKey.Escape);
+		harness.App.Step(3);
+
+		Assert.AreEqual(0, field.Commits);
+		Assert.AreEqual("Name", field.Model);
+	}
+
+	/// <summary>
+	/// An edit spanning several frames must accumulate. The scratch buffer is what carries it, so
+	/// this fails the moment the buffer is dropped or overwritten between frames.
+	/// </summary>
+	[TestMethod]
+	public void AnEditSpanningManyFramesKeepsEveryCharacter()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		TypeInto(field, "LongerReplacement");
+		CommitWithEnter();
+
+		Assert.AreEqual("LongerReplacement", field.LastCommit);
+	}
+
+	/// <summary>
+	/// Every member row in the editor draws its name field as "##Name" and relies on the
+	/// surrounding PushID to tell the rows apart. Keying the scratch buffer on the label rather
+	/// than the resolved id lets one row's half-typed text into the next row's field.
+	/// </summary>
+	/// <remarks>
+	/// The leak has to be measured on screen. ImGui keeps its own copy of the text while a widget
+	/// is being edited, so the row being typed into still commits the right value with the buffers
+	/// shared - the row that is wrong is the other one, which is handed its sibling's text to draw.
+	/// So this compares the pixels of the second row against the same pixels before the edit
+	/// started: nothing about that row changed, so nothing about it should be drawn differently.
+	/// </remarks>
+	[TestMethod]
+	public void TwoRowsSharingALabelDoNotShareABuffer()
+	{
+		Field first = new() { Model = "Alpha", Id = "##Name", Scope = "row0" };
+		Field second = new() { Model = "Beta", Id = "##Name", Scope = "row1" };
+		harness.Draw = () =>
+		{
+			first.Draw();
+			second.Draw();
+		};
+		harness.App.Step(3);
+
+		CapturedFrame before = harness.App.Capture();
+		Rectangle secondRow = second.Bounds;
+
+		// Long and unlike "Beta", so a leak into the second row is unmistakable on screen.
+		TypeInto(first, "WWWWWWWWWWWW");
+		CapturedFrame during = harness.App.Capture();
+
+		AssertUnchanged(before, during, secondRow, "The second row was redrawn while its sibling was being edited, so the sibling's text leaked into it.");
+
+		CommitWithEnter();
+
+		Assert.AreEqual("WWWWWWWWWWWW", first.LastCommit);
+		Assert.AreEqual(1, first.Commits);
+		Assert.AreEqual(0, second.Commits, "Editing one row wrote to another row's model.");
+		Assert.AreEqual("Beta", second.Model);
+	}
+
+	private static void AssertUnchanged(CapturedFrame before, CapturedFrame after, Rectangle region, string message)
+	{
+		for (int y = region.MinY; y < region.MaxY; y++)
+		{
+			for (int x = region.MinX; x < region.MaxX; x++)
+			{
+				if (before.GetPixel(x, y) != after.GetPixel(x, y))
+				{
+					Assert.Fail($"{message} First difference at ({x}, {y}).");
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// While a field is not being edited the model is the source of truth, so an undo that changes
+	/// the value shows up the moment the field is redrawn - and does not get written back over.
+	/// </summary>
+	[TestMethod]
+	public void AFieldThatIsNotBeingEditedFollowsTheModel()
+	{
+		Field field = new() { Model = "Name" };
+		harness.Draw = field.Draw;
+		harness.App.Step(2);
+
+		TypeInto(field, "User");
+		CommitWithEnter();
+		Assert.AreEqual("User", field.Model);
+
+		// What an undo of that rename does to the model.
+		field.Model = "Name";
+		harness.App.Step(5);
+
+		Assert.AreEqual(1, field.Commits, "The field wrote its own last text back over the undone value.");
+		Assert.AreEqual("Name", field.Model);
+	}
+}

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO.Abstractions.TestingHelpers;
+
+using ktsu.ImGui.App.Testing;
+
+/// <summary>
+/// An editor running headlessly, with frames advanced by the test rather than by a display.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The editor's code is immediate-mode draw calls: a value is read, a widget is drawn, and what the
+/// widget reports decides what happens next, all inside one function. None of that executes without
+/// a live ImGui context, which is why the editor had no tests at all. <see cref="ImGuiAppHarness"/>
+/// supplies that context with no window, no display and no GPU - it rasterizes in software and
+/// injects input straight into ImGui's event queue - so the real draw code runs on a headless
+/// continuous integration runner.
+/// </para>
+/// <para>
+/// The configuration comes from <see cref="Program.CreateConfig"/>, the same one the application
+/// starts with, so a callback renamed or dropped there breaks these tests instead of leaving them
+/// passing against a host that no longer exists.
+/// </para>
+/// <para>
+/// Settings are redirected to an in-memory file system before the editor is constructed, because
+/// <see cref="AppData"/> otherwise reads and writes the real settings of whoever runs the suite -
+/// and the editor saves them on exit, so a test could overwrite a developer's open document and
+/// recent files.
+/// </para>
+/// </remarks>
+internal sealed class EditorHarness : IDisposable
+{
+	/// <summary>
+	/// Gets the editor under test.
+	/// </summary>
+	internal SchemaEditor Editor { get; }
+
+	/// <summary>
+	/// Gets the harness advancing its frames.
+	/// </summary>
+	internal ImGuiAppHarness App { get; }
+
+	private bool disposed;
+
+	private EditorHarness(SchemaEditor editor, ImGuiAppHarness app)
+	{
+		Editor = editor;
+		App = app;
+	}
+
+	/// <summary>
+	/// Starts an editor with empty settings and advances the frames it needs to be drawing.
+	/// </summary>
+	/// <returns>The running harness. Dispose it to release the ImGui context.</returns>
+	internal static EditorHarness Start()
+	{
+		// Must precede the constructor: it is the constructor that loads the settings.
+		ktsu.AppDataStorage.AppData.ConfigureForTesting(() => new MockFileSystem());
+
+		SchemaEditor editor = new();
+		ImGuiAppHarness app = ImGuiAppHarness.Start(Program.CreateConfig(editor), new HarnessOptions());
+
+		// The first frame builds the font atlas and lays the panels out; nothing is measurable
+		// before it has run.
+		app.Step();
+
+		return new EditorHarness(editor, app);
+	}
+
+	/// <summary>
+	/// Advances frames until a condition holds, failing the test if it never does.
+	/// </summary>
+	/// <param name="condition">Checked before the first frame and after every frame.</param>
+	/// <param name="description">What was being waited for, for the failure message.</param>
+	/// <param name="maxFrames">The frame budget. Frames rather than time, so a loaded runner is slower without being flakier.</param>
+	internal void StepUntil(Func<bool> condition, string description, int maxFrames = 120)
+	{
+		if (!App.StepUntil(condition, maxFrames))
+		{
+			Assert.Fail($"{description} did not happen within {maxFrames} frames.");
+		}
+	}
+
+	public void Dispose()
+	{
+		if (disposed)
+		{
+			return;
+		}
+
+		disposed = true;
+		App.Dispose();
+		ktsu.AppDataStorage.AppData.ResetFileSystem();
+	}
+}

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -20,7 +20,7 @@ using ktsu.ImGui.App.Testing;
 /// continuous integration runner.
 /// </para>
 /// <para>
-/// The configuration comes from <see cref="Program.CreateConfig"/>, the same one the application
+/// The configuration comes from <see cref="EditorHost.CreateConfig"/>, the same one the application
 /// starts with, so a callback renamed or dropped there breaks these tests instead of leaving them
 /// passing against a host that no longer exists.
 /// </para>
@@ -61,7 +61,7 @@ internal sealed class EditorHarness : IDisposable
 		ktsu.AppDataStorage.AppData.ConfigureForTesting(() => new MockFileSystem());
 
 		SchemaEditor editor = new();
-		ImGuiAppHarness app = ImGuiAppHarness.Start(Program.CreateConfig(editor), new HarnessOptions());
+		ImGuiAppHarness app = ImGuiAppHarness.Start(EditorHost.CreateConfig(editor), new HarnessOptions());
 
 		// The first frame builds the font atlas and lays the panels out; nothing is measurable
 		// before it has run.

--- a/SchemaEditor.Test/HarnessSmokeTests.cs
+++ b/SchemaEditor.Test/HarnessSmokeTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+/// <summary>
+/// That the harness itself works: without these, a failure anywhere else is ambiguous between the
+/// editor being wrong and the harness never having drawn a frame.
+/// </summary>
+[TestClass]
+public sealed class HarnessSmokeTests
+{
+	[TestMethod]
+	public void EditorDrawsFramesHeadlessly()
+	{
+		using EditorHarness harness = EditorHarness.Start();
+
+		int before = harness.App.FrameCount;
+		harness.App.Step(3);
+
+		Assert.AreEqual(before + 3, harness.App.FrameCount);
+	}
+
+	[TestMethod]
+	public void EditorStartsWithNoDocument()
+	{
+		using EditorHarness harness = EditorHarness.Start();
+
+		Assert.IsNull(harness.Editor.CurrentSchema);
+		Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+		Assert.AreEqual("Untitled schema", harness.Editor.DocumentName);
+	}
+}

--- a/SchemaEditor.Test/RecentFilesTests.cs
+++ b/SchemaEditor.Test/RecentFilesTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System.Linq;
+
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// The recent-files list. Pure logic - no ImGui context needed - which is why it is the first
+/// thing here.
+/// </summary>
+[TestClass]
+public sealed class RecentFilesTests
+{
+	// AppData is disposable and saves on dispose if a save is outstanding, so even these
+	// filesystem-free tests are pointed at an in-memory store rather than the real settings of
+	// whoever runs the suite.
+	[TestInitialize]
+	public void RedirectSettings() =>
+		ktsu.AppDataStorage.AppData.ConfigureForTesting(() => new System.IO.Abstractions.TestingHelpers.MockFileSystem());
+
+	[TestCleanup]
+	public void RestoreSettings() => ktsu.AppDataStorage.AppData.ResetFileSystem();
+
+	private static AbsoluteFilePath Path(string name) =>
+		$"{(OperatingSystem.IsWindows() ? "C:\\schemas\\" : "/schemas/")}{name}".As<AbsoluteFilePath>();
+
+	[TestMethod]
+	public void RecordingAFilePutsItFirst()
+	{
+		using AppData options = new();
+
+		options.RecordRecentFile(Path("a.schema.json"));
+		options.RecordRecentFile(Path("b.schema.json"));
+
+		Assert.AreEqual(2, options.RecentFiles.Count);
+		Assert.AreEqual(Path("b.schema.json"), options.RecentFiles[0]);
+		Assert.AreEqual(Path("a.schema.json"), options.RecentFiles[1]);
+	}
+
+	[TestMethod]
+	public void RecordingAFileAgainMovesItRatherThanDuplicatingIt()
+	{
+		using AppData options = new();
+
+		options.RecordRecentFile(Path("a.schema.json"));
+		options.RecordRecentFile(Path("b.schema.json"));
+		options.RecordRecentFile(Path("a.schema.json"));
+
+		Assert.AreEqual(2, options.RecentFiles.Count);
+		Assert.AreEqual(Path("a.schema.json"), options.RecentFiles[0]);
+		Assert.AreEqual(Path("b.schema.json"), options.RecentFiles[1]);
+	}
+
+	[TestMethod]
+	public void RecordingIsBoundedAndDropsTheOldest()
+	{
+		using AppData options = new();
+
+		for (int index = 0; index < AppData.MaxRecentFiles + 5; index++)
+		{
+			options.RecordRecentFile(Path($"file{index}.schema.json"));
+		}
+
+		Assert.AreEqual(AppData.MaxRecentFiles, options.RecentFiles.Count);
+
+		// Newest first, so the most recently recorded file leads and the oldest survivor is the
+		// one recorded MaxRecentFiles ago.
+		Assert.AreEqual(Path($"file{AppData.MaxRecentFiles + 4}.schema.json"), options.RecentFiles[0]);
+		Assert.AreEqual(Path("file5.schema.json"), options.RecentFiles[^1]);
+		Assert.IsFalse(options.RecentFiles.Contains(Path("file0.schema.json")));
+	}
+
+	[TestMethod]
+	public void RecordingAnEmptyPathIsIgnored()
+	{
+		using AppData options = new();
+
+		options.RecordRecentFile(new AbsoluteFilePath());
+
+		Assert.AreEqual(0, options.RecentFiles.Count);
+	}
+
+	/// <summary>
+	/// A list that already holds duplicates - written by an older build, or hand-edited - must not
+	/// keep one of them behind when the file is recorded again.
+	/// </summary>
+	[TestMethod]
+	public void RecordingRemovesEveryEarlierCopy()
+	{
+		using AppData options = new();
+		options.RecentFiles.Add(Path("a.schema.json"));
+		options.RecentFiles.Add(Path("b.schema.json"));
+		options.RecentFiles.Add(Path("a.schema.json"));
+
+		options.RecordRecentFile(Path("a.schema.json"));
+
+		Assert.AreEqual(2, options.RecentFiles.Count);
+		Assert.AreEqual(1, options.RecentFiles.Count(p => p == Path("a.schema.json")));
+	}
+}

--- a/SchemaEditor.Test/SchemaEditor.Test.csproj
+++ b/SchemaEditor.Test/SchemaEditor.Test.csproj
@@ -1,0 +1,37 @@
+<Project>
+  <Sdk Name="MSTest.Sdk" />
+  <Import Project="Sdk.props" Sdk="ktsu.Sdk" />
+
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SchemaEditor\SchemaEditor.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- The headless harness: it drives ImGuiApp frames through a software rasterizer, so the
+         editor's draw code runs with no window, no display and no GPU. -->
+    <PackageReference Include="ktsu.ImGui.App.Testing" />
+    <!-- A mock file system for AppDataStorage, so a test never reads or writes the settings of
+         whoever is running it. -->
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Testing.Extensions.CodeCoverage">
+      <VersionOverride>18.8.0</VersionOverride>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="Sdk.targets" Sdk="ktsu.Sdk" />
+
+  <!-- SchemaEditor is a net10.0-only application, so this suite is too. Placed after the explicit
+       Sdk.targets import so the project, not the SDK, has the last word - the same reason
+       Schema.Test states its frameworks there. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+</Project>

--- a/SchemaEditor.Test/WidgetHarness.cs
+++ b/SchemaEditor.Test/WidgetHarness.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+
+using ktsu.ImGui.App;
+using ktsu.ImGui.App.Testing;
+
+/// <summary>
+/// A headless ImGui frame with nothing in it but the widget under test.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="EditorHarness"/>, which drives the whole editor through the real
+/// application configuration. A widget like <see cref="EditField"/> is a unit below that: what is
+/// being tested is how it behaves across frames as ImGui reports the widget activating,
+/// being edited and deactivating, and putting the whole editor on screen to reach it would only
+/// add ways for the test to fail for reasons that are not the widget's.
+/// </remarks>
+internal sealed class WidgetHarness : IDisposable
+{
+	/// <summary>
+	/// Gets the harness advancing the frames.
+	/// </summary>
+	internal ImGuiAppHarness App { get; }
+
+	/// <summary>
+	/// Gets or sets what to draw each frame. Called from inside a live frame, so it may call ImGui
+	/// freely.
+	/// </summary>
+	internal Action Draw { get; set; } = () => { };
+
+	private bool disposed;
+
+	private WidgetHarness(ImGuiAppHarness app) => App = app;
+
+	/// <summary>
+	/// Starts a harness and advances the first frame, which builds the font atlas.
+	/// </summary>
+	/// <returns>The running harness. Dispose it to release the ImGui context.</returns>
+	internal static WidgetHarness Start()
+	{
+		WidgetHarness? harness = null;
+
+		ImGuiAppConfig config = new()
+		{
+			Title = nameof(WidgetHarness),
+			OnRender = _ => harness?.Draw(),
+		};
+
+		ImGuiAppHarness app = ImGuiAppHarness.Start(config, new HarnessOptions());
+		harness = new WidgetHarness(app);
+		app.Step();
+
+		return harness;
+	}
+
+	public void Dispose()
+	{
+		if (disposed)
+		{
+			return;
+		}
+
+		disposed = true;
+		App.Dispose();
+	}
+}

--- a/SchemaEditor/AppData.cs
+++ b/SchemaEditor/AppData.cs
@@ -1,5 +1,10 @@
 // Copyright (c) 2023-2026 ktsu-dev contributors
 
+// Both test assemblies are named, rather than only the one that reads this project's internals.
+// ktsu.Sdk's KTSU0002 requires a non-test project to expose its internals to the repository's test
+// projects, and there are two of them now; which of the two a given project actually needs is not
+// what the rule is checking.
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.SchemaEditor.Test")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.Schema.Test")]
 
 namespace ktsu.SchemaEditor;

--- a/SchemaEditor/EditorHost.cs
+++ b/SchemaEditor/EditorHost.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using ktsu.ImGui.App;
+
+/// <summary>
+/// The host configuration an editor runs under.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="SchemaEditor"/> because describing the host is not part of editing a
+/// schema: the configuration names a windowing framework and a delegate type for each callback,
+/// and holding all of that in the editor class counts against its coupling budget without earning
+/// anything. It also keeps the whole of the host's contract with ImGuiApp readable in one place.
+///
+/// Separate from <see cref="Program"/> for the same reason one level down: describing the host is
+/// not the same as starting it. Describing it is testable and tested; starting it opens a window
+/// and does not return.
+/// </remarks>
+internal static class EditorHost
+{
+	/// <summary>
+	/// Builds the host configuration for an editor instance.
+	/// </summary>
+	/// <remarks>
+	/// Takes the editor rather than reaching for <see cref="SchemaEditor.Instance"/> so the
+	/// headless test harness can drive frames through the same configuration the real application
+	/// runs. A test that assembled its own callbacks would be exercising a parallel host rather
+	/// than this one, and would keep passing after a callback here was renamed or dropped.
+	/// </remarks>
+	/// <param name="editor">The editor the callbacks are bound to.</param>
+	/// <returns>The configuration to hand to <see cref="ImGuiApp"/>.</returns>
+	internal static ImGuiAppConfig CreateConfig(SchemaEditor editor) =>
+		new()
+		{
+			// The startup title only; SchemaEditor keeps it current from there, showing the open
+			// document and whether it has unsaved changes.
+			Title = nameof(SchemaEditor),
+			OnStart = SchemaEditor.OnStart,
+			OnUpdate = editor.OnTick,
+			OnRender = editor.OnRender,
+			OnAppMenu = editor.OnMenu,
+
+			// Refuses a close that would discard unsaved work, so the editor can ask first.
+			OnClosing = editor.ShouldClose,
+		};
+}

--- a/SchemaEditor/Program.cs
+++ b/SchemaEditor/Program.cs
@@ -8,39 +8,12 @@ using ktsu.ImGui.App;
 /// The application entry point.
 /// </summary>
 /// <remarks>
-/// Separate from <see cref="SchemaEditor"/> because starting the application is not part of editing
-/// a schema: the configuration names a windowing framework and a delegate type for each callback,
-/// and holding all of that in the editor class counts against its coupling budget without earning
-/// anything. It also keeps the whole of the host's contract with ImGuiApp readable in one place.
+/// This file holds the one statement that cannot be executed by a test: it opens a window and does
+/// not return until the application closes. That is why it is a file of its own, and the only part
+/// of the editor excluded from coverage measurement - what the host is configured with lives in
+/// <see cref="EditorHost"/>, which the tests drive.
 /// </remarks>
 internal static class Program
 {
-	/// <summary>
-	/// Builds the host configuration for an editor instance.
-	/// </summary>
-	/// <remarks>
-	/// Split out from <see cref="Main"/>, and taking the editor rather than reaching for
-	/// <see cref="SchemaEditor.Instance"/>, so the headless test harness can drive frames through
-	/// the same configuration the real application runs. A test that assembled its own callbacks
-	/// would be exercising a parallel host rather than this one, and would keep passing after a
-	/// callback here was renamed or dropped.
-	/// </remarks>
-	/// <param name="editor">The editor the callbacks are bound to.</param>
-	/// <returns>The configuration to hand to <see cref="ImGuiApp"/>.</returns>
-	internal static ImGuiAppConfig CreateConfig(SchemaEditor editor) =>
-		new()
-		{
-			// The startup title only; SchemaEditor keeps it current from there, showing the open
-			// document and whether it has unsaved changes.
-			Title = nameof(SchemaEditor),
-			OnStart = SchemaEditor.OnStart,
-			OnUpdate = editor.OnTick,
-			OnRender = editor.OnRender,
-			OnAppMenu = editor.OnMenu,
-
-			// Refuses a close that would discard unsaved work, so the editor can ask first.
-			OnClosing = editor.ShouldClose,
-		};
-
-	private static void Main(string[] _) => ImGuiApp.Start(CreateConfig(SchemaEditor.Instance));
+	private static void Main(string[] _) => ImGuiApp.Start(EditorHost.CreateConfig(SchemaEditor.Instance));
 }

--- a/SchemaEditor/Program.cs
+++ b/SchemaEditor/Program.cs
@@ -15,18 +15,32 @@ using ktsu.ImGui.App;
 /// </remarks>
 internal static class Program
 {
-	private static void Main(string[] _) =>
-		ImGuiApp.Start(new()
+	/// <summary>
+	/// Builds the host configuration for an editor instance.
+	/// </summary>
+	/// <remarks>
+	/// Split out from <see cref="Main"/>, and taking the editor rather than reaching for
+	/// <see cref="SchemaEditor.Instance"/>, so the headless test harness can drive frames through
+	/// the same configuration the real application runs. A test that assembled its own callbacks
+	/// would be exercising a parallel host rather than this one, and would keep passing after a
+	/// callback here was renamed or dropped.
+	/// </remarks>
+	/// <param name="editor">The editor the callbacks are bound to.</param>
+	/// <returns>The configuration to hand to <see cref="ImGuiApp"/>.</returns>
+	internal static ImGuiAppConfig CreateConfig(SchemaEditor editor) =>
+		new()
 		{
 			// The startup title only; SchemaEditor keeps it current from there, showing the open
 			// document and whether it has unsaved changes.
 			Title = nameof(SchemaEditor),
 			OnStart = SchemaEditor.OnStart,
-			OnUpdate = SchemaEditor.Instance.OnTick,
-			OnRender = SchemaEditor.Instance.OnRender,
-			OnAppMenu = SchemaEditor.Instance.OnMenu,
+			OnUpdate = editor.OnTick,
+			OnRender = editor.OnRender,
+			OnAppMenu = editor.OnMenu,
 
 			// Refuses a close that would discard unsaved work, so the editor can ask first.
-			OnClosing = SchemaEditor.Instance.ShouldClose,
-		});
+			OnClosing = editor.ShouldClose,
+		};
+
+	private static void Main(string[] _) => ImGuiApp.Start(CreateConfig(SchemaEditor.Instance));
 }

--- a/SchemaEditor/SchemaEditor.Diagnostics.cs
+++ b/SchemaEditor/SchemaEditor.Diagnostics.cs
@@ -25,7 +25,7 @@ public partial class SchemaEditor
 	/// frame budget on a schema that has not changed. Debouncing also means a burst of edits -
 	/// deleting a class, then its data source - validates once rather than once per edit.
 	/// </remarks>
-	private const float ValidationDebounceSeconds = 0.35f;
+	internal const float ValidationDebounceSeconds = 0.35f;
 
 	private bool validationPending;
 	private float timeSinceValidationRequested;
@@ -48,7 +48,7 @@ public partial class SchemaEditor
 		timeSinceValidationRequested = 0f;
 	}
 
-	private void UpdateValidation(float dt)
+	internal void UpdateValidation(float dt)
 	{
 		if (!validationPending)
 		{
@@ -149,7 +149,7 @@ public partial class SchemaEditor
 	/// unambiguously split when a name contains a dot. A member selects its owning class, because
 	/// that is the panel its row is drawn in.
 	/// </remarks>
-	private void NavigateTo(SchemaValidationIssue issue)
+	internal void NavigateTo(SchemaValidationIssue issue)
 	{
 		switch (issue.Element)
 		{

--- a/SchemaEditor/SchemaEditor.Files.cs
+++ b/SchemaEditor/SchemaEditor.Files.cs
@@ -103,7 +103,7 @@ public partial class SchemaEditor
 	/// Run if the user backs out. Only the close path needs this, to release the latch that stops a
 	/// second prompt stacking on the first; New and Open simply do nothing.
 	/// </param>
-	private void WithUnsavedChangesGuard(Action proceed, Action? onCancel = null)
+	internal void WithUnsavedChangesGuard(Action proceed, Action? onCancel = null)
 	{
 		if (!HasUnsavedChanges)
 		{
@@ -122,7 +122,7 @@ public partial class SchemaEditor
 			});
 	}
 
-	private void New() => WithUnsavedChangesGuard(NewInternal);
+	internal void New() => WithUnsavedChangesGuard(NewInternal);
 
 	private void NewInternal()
 	{
@@ -137,7 +137,7 @@ public partial class SchemaEditor
 	private void OpenInternal() =>
 		Popups.OpenBrowserFileOpen("Open Schema", LoadFrom, "*.schema.json");
 
-	private void LoadFrom(AbsoluteFilePath filePath)
+	internal void LoadFrom(AbsoluteFilePath filePath)
 	{
 		SchemaLoadResult result = SchemaFile.Load(filePath);
 
@@ -185,7 +185,7 @@ public partial class SchemaEditor
 	/// appeared has to wait for that answer rather than running immediately.
 	/// </remarks>
 	/// <param name="continuation">What to do after a successful save, if anything.</param>
-	private void SaveThen(Action? continuation)
+	internal void SaveThen(Action? continuation)
 	{
 		if (string.IsNullOrEmpty(CurrentSchemaPath))
 		{
@@ -267,7 +267,7 @@ public partial class SchemaEditor
 	/// <summary>
 	/// Raises the unsaved-changes prompt for a close that <see cref="ShouldClose"/> refused.
 	/// </summary>
-	private void ProcessCloseRequest()
+	internal void ProcessCloseRequest()
 	{
 		if (!closeRequested || closePromptShowing)
 		{

--- a/SchemaEditor/SchemaEditor.csproj
+++ b/SchemaEditor/SchemaEditor.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="ktsu.Semantics.Paths" />
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="ktsu.UndoRedo.Core" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" />
     <PackageReference Include="Polyfill" PrivateAssets="all" />

--- a/SchemaTool/Program.cs
+++ b/SchemaTool/Program.cs
@@ -1,6 +1,11 @@
 // Copyright (c) 2023-2026 ktsu-dev contributors
 
+// Both test assemblies are named, rather than only the one that reads this project's internals.
+// ktsu.Sdk's KTSU0002 requires a non-test project to expose its internals to the repository's test
+// projects, and there are two of them now; which of the two a given project actually needs is not
+// what the rule is checking.
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.Schema.Test")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("ktsu.SchemaEditor.Test")]
 
 namespace ktsu.SchemaTool;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,8 @@ if (SchemaSerializer.TryDeserialize(File.ReadAllText("user.schema.json"), out Sc
 
 -   **[Schema](api/schema-core.md)** - Core library containing the schema definition system
 -   **[SchemaEditor](features/schema-editor.md)** - Visual editor application
--   **Schema.Test** - MSTest suite for the library (see the [development guide](development/README.md))
+-   **SchemaTool** - Command line validator and code generator runner
+-   **Schema.Test** / **SchemaEditor.Test** - MSTest suites for the library and the editor (see the [development guide](development/README.md))
 
 ## Documentation
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,6 +38,9 @@ time. For what the library actually does, the tests in
   recent-files list.
 - **CLI** — `SchemaTool` validates a schema or runs its code generators, exiting non-zero on
   errors so it can gate a build.
+- **Editor tests** — `SchemaEditor.Test` drives the editor headlessly through
+  `ktsu.ImGui.App.Testing`, which rasterizes in software and injects input straight into ImGui, so
+  the editor's real draw code runs on a continuous integration runner with no window or display.
 - **CI/CD** — GitHub Actions with build, multi-framework test, SonarCloud analysis, CodeQL, NuGet
   publishing and winget manifest updates; Dependabot with auto-merge.
 
@@ -49,10 +52,8 @@ substantial items:
 | Issue | Work | Why it is not done |
 | --- | --- | --- |
 | [#110](https://github.com/ktsu-dev/Schema/issues/110) | Implement or delete the unused `Schema.Contracts` API | Needs a decision from the project owner; deleting is a breaking change |
-| [#116](https://github.com/ktsu-dev/Schema/issues/116) | Editor window title and close prompt | Blocked by `ktsu.ImGui.App`: `Title` is init-only and there is no cancellable close hook |
 | [#126](https://github.com/ktsu-dev/Schema/issues/126) | Generated data editors | Builds on the generator architecture |
 | [#127](https://github.com/ktsu-dev/Schema/issues/127) | Generated data migrations | Needs a schema diff, which does not exist yet |
-| [#128](https://github.com/ktsu-dev/Schema/issues/128) | A test harness for the editor | The editor has never had tests; its code needs a live ImGui context to run |
 
 ## Phase status
 
@@ -66,16 +67,17 @@ build blocker that made the repository unbuildable on a current SDK
 ([#123](https://github.com/ktsu-dev/Schema/issues/123)) is fixed, and the test suite now runs
 against every published target framework rather than just the newest.
 
-### Phase 2 — Editor completeness — **done except two window behaviours**
+### Phase 2 — Editor completeness — **done**
 
 Renaming, descriptions, the code generator panel, member reordering, validation surfacing, undo
 coverage, Save As, dirty tracking and recent files have landed. Cross-platform "Open Externally"
 is fixed.
 
-Outstanding: the window title cannot reflect the open document and the window's close button
-cannot prompt to save, because `ktsu.ImGui.App` exposes neither a settable title nor a cancellable
-close hook. The document name, dirty marker and a guarded Exit item live in the menu bar instead.
-Both would be small upstream changes to that package.
+The window title and the close prompt ([#116](https://github.com/ktsu-dev/Schema/issues/116)) were
+blocked on `ktsu.ImGui.App` exposing neither a settable title nor a cancellable close hook; both
+landed upstream, and the editor now keeps its title current and refuses a close that would discard
+unsaved work. The document name and dirty marker are still drawn in the menu bar as well, because a
+maximised title bar is easy to overlook and a tiling window manager may not draw one at all.
 
 ### Phase 3 — Code generation — **done, less the deferred targets**
 
@@ -98,16 +100,25 @@ The `.schema.json` format is documented and versioned with a stated compatibilit
 
 Outstanding: editor packaging via winget, and cutting the v2.0 milestone.
 
+### Phase 6 — Test coverage — **the editor is now testable**
+
+Not one of the original phases; added when the editor grew large enough to need one.
+
+`SchemaEditor.Test` ([#128](https://github.com/ktsu-dev/Schema/issues/128)) drives the editor
+headlessly and covers the recent-files list, the commit-once text field, the unsaved-changes guard
+and the save-then-continue sequence, and validation debouncing and click-to-navigate. The
+SonarCloud coverage exclusion has narrowed from the whole application to the panel and tree files,
+which are still pure draw code.
+
 ## What to do next
 
 | Order | Work item | Effort | Rationale |
 | ----- | --- | --- | --- |
 | 1 | Decide [#110](https://github.com/ktsu-dev/Schema/issues/110): implement or delete `Schema.Contracts` | S | A decision, not a build. It is public API on a published package that nothing implements, and `docs/examples/dependency-injection.md` documents it as though it works |
-| 2 | [#128](https://github.com/ktsu-dev/Schema/issues/128): a test harness for the editor | M | The editor is now the largest untested surface, and it grew a lot recently |
-| 3 | [#126](https://github.com/ktsu-dev/Schema/issues/126): generated data editors | L | The first thing the data source binding was for |
-| 4 | Upstream the two `ktsu.ImGui.App` changes, then finish [#116](https://github.com/ktsu-dev/Schema/issues/116) | S | Small change in another repository, then a small change here |
-| 5 | [#127](https://github.com/ktsu-dev/Schema/issues/127): generated migrations | L | Needs a schema diff first; the largest remaining design problem |
-| 6 | Editor packaging and the v2.0 milestone | M | Ship it |
+| 2 | [#126](https://github.com/ktsu-dev/Schema/issues/126): generated data editors | L | The first thing the data source binding was for |
+| 3 | Extend `SchemaEditor.Test` to the panel and tree files | M | The harness exists; those files are what it does not reach yet, and they are the ones still excluded from coverage |
+| 4 | [#127](https://github.com/ktsu-dev/Schema/issues/127): generated migrations | L | Needs a schema diff first; the largest remaining design problem |
+| 5 | Editor packaging and the v2.0 milestone | M | Ship it |
 
 ## Decisions
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -78,7 +78,7 @@ headless continuous integration runner and disturb nothing on a desktop.
 
 Two fixtures wrap it:
 
--   **`EditorHarness`** starts a real editor from `Program.CreateConfig`, the same configuration
+-   **`EditorHarness`** starts a real editor from `EditorHost.CreateConfig`, the same configuration
     the application itself starts with, so a callback renamed or dropped there breaks the tests
     rather than leaving them passing against a host that no longer exists. It redirects
     `AppDataStorage` to an in-memory file system first, so a test never reads or writes the

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -43,11 +43,13 @@ dotnet run --project SchemaEditor
 
 | Directory       | Purpose                        |
 | --------------- | ------------------------------ |
-| `Schema/`       | Core schema definition library |
-| `Schema.Test/`  | MSTest unit tests              |
-| `SchemaEditor/` | ImGui-based visual editor      |
-| `docs/`         | Markdown documentation         |
-| `scripts/`      | Build automation (PSBuild)     |
+| `Schema/`             | Core schema definition library      |
+| `Schema.Test/`        | MSTest unit tests for the library   |
+| `SchemaEditor/`       | ImGui-based visual editor           |
+| `SchemaEditor.Test/`  | Headless UI tests for the editor    |
+| `SchemaTool/`         | Command line validator and generator |
+| `docs/`               | Markdown documentation              |
+| `scripts/`            | Build automation (PSBuild)          |
 
 Within the core library:
 
@@ -58,7 +60,43 @@ Within the core library:
 
 ## Testing
 
-Tests live in `Schema.Test` and use MSTest with the Microsoft.Testing.Platform runner. Run them with `dotnet test`. All new features should include tests; the existing suites (`SchemaTests`, `SchemaClassTests`, `SchemaEnumTests`, `TypeSystemTests`, `SchemaSerializerTests`, `AddClassFromTypeTests`) show the conventions in use.
+Both suites use MSTest with the Microsoft.Testing.Platform runner, and `dotnet test` runs them
+together. All new features should include tests.
+
+### The library — `Schema.Test`
+
+Plain unit tests over the core library, run against every framework it publishes. The existing
+suites (`SchemaTests`, `SchemaClassTests`, `SchemaEnumTests`, `TypeSystemTests`,
+`SchemaSerializerTests`, `AddClassFromTypeTests`) show the conventions in use.
+
+### The editor — `SchemaEditor.Test`
+
+The editor's code is immediate-mode draw calls, so none of it executes without a live ImGui
+context. `ktsu.ImGui.App.Testing` supplies one with no window, no display and no GPU: it rasterizes
+in software and injects input straight into ImGui's event queue, so these tests run unchanged on a
+headless continuous integration runner and disturb nothing on a desktop.
+
+Two fixtures wrap it:
+
+-   **`EditorHarness`** starts a real editor from `Program.CreateConfig`, the same configuration
+    the application itself starts with, so a callback renamed or dropped there breaks the tests
+    rather than leaving them passing against a host that no longer exists. It redirects
+    `AppDataStorage` to an in-memory file system first, so a test never reads or writes the
+    settings of whoever is running it.
+-   **`WidgetHarness`** draws one widget and nothing else, for widget-level behaviour such as
+    `EditField`.
+
+Frames are advanced by the test, never by wall-clock time — `Step(n)` for a fixed number and
+`StepUntil(condition, budget)` for a wait — so a loaded runner is slower rather than flakier.
+Widgets are addressed by name through `App.Probe` and `App.Click(name)` where the widget library
+records them, and by measured rectangle otherwise. Where a regression is only visible on screen,
+`App.Capture()` gives the rendered pixels: `TwoRowsSharingALabelDoNotShareABuffer` compares one
+row's pixels before and during an edit of its sibling, which is the only place the shared-buffer
+bug it guards against is observable at all.
+
+Note that a modal sizes itself on the frame it appears and is centred on the next, so a button's
+rectangle is not final until a few frames after it is first recorded. Step past that before
+clicking.
 
 ## Code Style
 


### PR DESCRIPTION
Two things: `main` does not currently build, and #128 — the editor has never had a test.

## 1. The build (first commit)

The `.NET Workflow` has been failing on `main` ([run 33815693131](https://github.com/ktsu-dev/Schema/actions/runs/33815693131)) with three `NU1608` errors. `SchemaEditor` pulls `Hexa.NET.ImGui.Widgets.Extras` transitively, which pins `Microsoft.CodeAnalysis.CSharp.Scripting` 4.14.0, and that in turn pins `Microsoft.CodeAnalysis.Common` and `.CSharp` to exactly 4.14.0. The project also names `Microsoft.CodeAnalysis.CSharp` directly, resolved at 5.9.0 by central package management, and NuGet rejects the conflict as an error because warnings are errors here.

Nothing in `SchemaEditor` uses Roslyn — the only `CodeAnalysis` in its source is `System.Diagnostics.CodeAnalysis`, which is in the BCL. So the reference is removed rather than downgraded, and the transitive constraint resolves on its own. `Schema.Test` keeps its own reference at 5.9.0 (it genuinely compiles generated source) and has no ImGui dependency to conflict with.

## 2. A test harness for the editor (#128)

`ktsu.ImGui.App.Testing` supplies an ImGui context with no window, no display and no GPU: it rasterizes in software and injects input straight into ImGui's event queue. The editor's real draw code now runs on a headless CI runner, and disturbs nothing on a desktop.

Two fixtures wrap it:

- **`EditorHarness`** starts a real editor from `EditorHost.CreateConfig` — the same configuration the application itself starts with, so a callback renamed or dropped there breaks the tests rather than leaving them passing against a host that no longer exists. It redirects `AppDataStorage` to an in-memory file system first, so a test never reads or writes the settings of whoever is running it.
- **`WidgetHarness`** draws one widget and nothing else.

Frames are advanced by the test, never by wall-clock time, so a loaded runner is slower rather than flakier.

### What is covered

46 tests, over what the issue listed:

| Area | Covered |
| --- | --- |
| `AppData.RecordRecentFile` | Ordering, deduplication (including a list that already held duplicates), bounding, empty path |
| `EditField` | One write per editing session however many frames it spans; nothing written when a field is left untouched or an edit is abandoned with Escape; an edit spanning frames keeps every character; a field not being edited follows the model, so an undo is not written back over |
| `SchemaEditor.Files` | The unsaved-changes guard, with Save / Discard / Cancel each driven by clicking the prompt in a rendered frame; a save with no path defers to the file browser instead of running its continuation; a failed save does not run it; closing is refused while work would be lost, without stacking a prompt per attempt |
| `SchemaEditor.Diagnostics` | Validation waits for the schema to settle, each edit restarts the debounce, it does not re-run unprompted, and clicking an issue selects the right element for every element kind |

### The one that needed pixels

`TwoRowsSharingALabelDoNotShareABuffer` guards the bug review found in #125. ImGui keeps its own copy of the text while a widget is being edited, so with the buffers wrongly shared the row being typed into still commits the right value — the row that is wrong is the *other* one, handed its sibling's text to draw. The test compares that row's pixels before and during the edit. Reintroducing the label-keyed buffer fails it, and nothing else in the suite notices; I checked both ways.

### Production changes

Confined to what the tests need to reach:

- The host configuration moves out of `Program.cs` into `EditorHost.CreateConfig`, taking the editor as a parameter so the harness can drive the same configuration the application runs. `Program.cs` is left holding only `Main`.
- A handful of members on `SchemaEditor` widen from `private` to `internal`.
- Both `InternalsVisibleTo` names are given on each non-test project, since there are two test assemblies now and `KTSU0002` is not checking which one reads what.

### Coverage exclusion

Narrowed from `SchemaEditor/**/*.cs` to the panel and tree files, which are still pure draw code this harness does not reach yet — the issue's third acceptance criterion. Extending it to them is now a matter of writing tests, not of building anything, and is recorded as the next step in the roadmap.

The one other exclusion is `SchemaEditor/Program.cs`, and it is there for a different reason: it holds only `Main`, which calls `ImGuiApp.Start`, opens a window and does not return. That is a line that cannot be executed by a test rather than one nobody has got to yet — which is why the configuration it passes lives in `EditorHost.cs` and stays measured.

## Also

`docs/ROADMAP.md` Phase 2 still described #116 as blocked on upstream `ktsu.ImGui.App` changes; both landed and the editor implements them, so that is corrected, along with the project lists in `README.md`, `docs/README.md` and `CLAUDE.md`.

## Verification

345 tests, 0 failures (299 library + 46 editor), green on both `ubuntu-latest` and `windows-latest` in CI. The editor suite passing on a Linux runner is what makes the "no window, no display, no GPU" claim more than a hope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc8o5zF3cmfCGjzWvQdGDE