### PR TITLE
Theme the editor with ktsu.ThemeProvider, and stop clipping tree labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Schema elements maintain parent references via `AssociateWith()` methods. After 
 - `Schema/Models/SchemaClass.cs` - Class definitions containing `SchemaMember` collections
 - `SchemaEditor/SchemaEditor.cs` - Main editor application using `ktsu.ImGui.App`
 - `SchemaEditor/EditorHost.cs` - Builds the `ImGuiAppConfig`; `CreateConfig` is what the tests drive too
+- `SchemaEditor/EditorTheme.cs` - The ktsu.ThemeProvider theme, and the one definition of how a validation issue is coloured
 - `SchemaEditor/Program.cs` - The entry point, and the only file excluded from coverage measurement
 - `SchemaEditor.Test/EditorHarness.cs` - Runs a real editor headlessly, frames advanced by the test
 - `SchemaEditor.Test/WidgetHarness.cs` - A headless frame containing only the widget under test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="ktsu.ForceDirectedLayout" Version="3.16.6" />
     <PackageVersion Include="ktsu.FuzzySearch" Version="1.2.39" />
     <PackageVersion Include="ktsu.ImGui.Styler" Version="3.16.6" />
+    <PackageVersion Include="ktsu.ThemeProvider" Version="3.0.14" />
     <PackageVersion Include="ktsu.IntervalAction" Version="1.3.41" />
     <PackageVersion Include="ktsu.Keybinding.Core" Version="1.0.41" />
     <PackageVersion Include="ktsu.UndoRedo.Core" Version="1.0.19" />

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -55,13 +55,25 @@ internal sealed class EditorHarness : IDisposable
 	/// Starts an editor with empty settings and advances the frames it needs to be drawing.
 	/// </summary>
 	/// <returns>The running harness. Dispose it to release the ImGui context.</returns>
-	internal static EditorHarness Start()
+	internal static EditorHarness Start() => Start(new HarnessOptions());
+
+	/// <summary>
+	/// Starts an editor at a chosen display size.
+	/// </summary>
+	/// <remarks>
+	/// Size matters to more than layout: the editor derives its field and column widths from the
+	/// display width, so a narrow window is what puts a long label past the width its column
+	/// gives it.
+	/// </remarks>
+	/// <param name="options">Determinism settings, including the display size.</param>
+	/// <returns>The running harness. Dispose it to release the ImGui context.</returns>
+	internal static EditorHarness Start(HarnessOptions options)
 	{
 		// Must precede the constructor: it is the constructor that loads the settings.
 		ktsu.AppDataStorage.AppData.ConfigureForTesting(() => new MockFileSystem());
 
 		SchemaEditor editor = new();
-		ImGuiAppHarness app = ImGuiAppHarness.Start(EditorHost.CreateConfig(editor), new HarnessOptions());
+		ImGuiAppHarness app = ImGuiAppHarness.Start(EditorHost.CreateConfig(editor), options);
 
 		// The first frame builds the font atlas and lays the panels out; nothing is measurable
 		// before it has run.

--- a/SchemaEditor.Test/SchemaEditor.Test.csproj
+++ b/SchemaEditor.Test/SchemaEditor.Test.csproj
@@ -14,6 +14,7 @@
     <!-- The headless harness: it drives ImGuiApp frames through a software rasterizer, so the
          editor's draw code runs with no window, no display and no GPU. -->
     <PackageReference Include="ktsu.ImGui.App.Testing" />
+    <PackageReference Include="ktsu.ImGui.Styler" />
     <PackageReference Include="ktsu.ThemeProvider" />
     <!-- A mock file system for AppDataStorage, so a test never reads or writes the settings of
          whoever is running it. -->

--- a/SchemaEditor.Test/SchemaEditor.Test.csproj
+++ b/SchemaEditor.Test/SchemaEditor.Test.csproj
@@ -14,6 +14,7 @@
     <!-- The headless harness: it drives ImGuiApp frames through a software rasterizer, so the
          editor's draw code runs with no window, no display and no GPU. -->
     <PackageReference Include="ktsu.ImGui.App.Testing" />
+    <PackageReference Include="ktsu.ThemeProvider" />
     <!-- A mock file system for AppDataStorage, so a test never reads or writes the settings of
          whoever is running it. -->
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />

--- a/SchemaEditor.Test/ThemeBrowserTests.cs
+++ b/SchemaEditor.Test/ThemeBrowserTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+/// <summary>
+/// Picking a theme from the browser the Theme menu opens.
+/// </summary>
+/// <remarks>
+/// The themes named here are ones near the top of the browser's grid. The grid scrolls, and a card
+/// below the fold is recorded by the probe at a position that is clipped away, so clicking it hits
+/// the modal behind rather than the card.
+/// </remarks>
+[TestClass]
+public sealed class ThemeBrowserTests
+{
+	private EditorHarness harness = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+		harness.Editor.Options.ThemeName = string.Empty;
+		harness.Editor.OnStart();
+	}
+
+	[TestCleanup]
+	public void StopEditor() => harness.Dispose();
+
+	[TestMethod]
+	public void ChoosingAThemeAppliesIt()
+	{
+		EditorTheme.OpenBrowser();
+
+		harness.Click("theme-card/Dracula");
+
+		Assert.AreEqual("Dracula", EditorTheme.CurrentName);
+	}
+
+	/// <summary>
+	/// The choice has to reach the settings, or it is gone at the next launch - which is the whole
+	/// point of storing it.
+	/// </summary>
+	[TestMethod]
+	public void ChoosingAThemeRemembersIt()
+	{
+		EditorTheme.OpenBrowser();
+
+		harness.Click("theme-card/Gruvbox Dark");
+
+		Assert.AreEqual("Gruvbox Dark", harness.Editor.Options.ThemeName);
+	}
+
+	/// <summary>
+	/// A theme chosen now is the theme applied on the next start, which is the round trip the
+	/// setting exists for.
+	/// </summary>
+	[TestMethod]
+	public void ARememberedThemeComesBackOnTheNextStart()
+	{
+		EditorTheme.OpenBrowser();
+		harness.Click("theme-card/Dracula");
+
+		EditorTheme.Apply("Nord");
+		Assert.AreEqual("Nord", EditorTheme.CurrentName);
+
+		harness.Editor.OnStart();
+
+		Assert.AreEqual("Dracula", EditorTheme.CurrentName);
+	}
+}

--- a/SchemaEditor.Test/ThemeTests.cs
+++ b/SchemaEditor.Test/ThemeTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+/// <summary>
+/// Which ktsu.ThemeProvider theme the editor runs under, and where that choice comes from.
+/// </summary>
+/// <remarks>
+/// The editor used to have no theme at all. It wrapped every frame in
+/// <c>Theme.FromColor(Palette.Semantic.Primary)</c> - a scoped colour meant for one widget -
+/// which tinted the entire interface with the primary colour and left an ordinary button looking
+/// the same as one marked with an error.
+/// </remarks>
+[TestClass]
+public sealed class ThemeTests
+{
+	private EditorHarness harness = null!;
+
+	[TestInitialize]
+	public void StartEditor() => harness = EditorHarness.Start();
+
+	[TestCleanup]
+	public void StopEditor() => harness.Dispose();
+
+	/// <summary>
+	/// Settings that name no theme still get one, rather than falling back to unstyled ImGui.
+	/// </summary>
+	[TestMethod]
+	public void SettingsWithNoThemeGetTheDefault()
+	{
+		EditorTheme.Apply(string.Empty);
+
+		Assert.AreEqual("VSCode Dark", EditorTheme.CurrentName);
+	}
+
+	[TestMethod]
+	public void ANamedThemeIsApplied()
+	{
+		EditorTheme.Apply("Nord");
+
+		Assert.AreEqual("Nord", EditorTheme.CurrentName);
+	}
+
+	/// <summary>
+	/// A theme that has left the registry - renamed upstream, or dropped - must not leave the
+	/// editor unstyled, because the name is read from settings written by an older build.
+	/// </summary>
+	[TestMethod]
+	public void AThemeThatIsNoLongerRegisteredFallsBack()
+	{
+		EditorTheme.Apply("A Theme That Does Not Exist");
+
+		Assert.AreEqual("VSCode Dark", EditorTheme.CurrentName);
+	}
+
+	[TestMethod]
+	public void TheSavedThemeIsAppliedWhenTheEditorStarts()
+	{
+		harness.Editor.Options.ThemeName = "Gruvbox Dark";
+
+		harness.Editor.OnStart();
+
+		Assert.AreEqual("Gruvbox Dark", EditorTheme.CurrentName);
+	}
+
+	/// <summary>
+	/// Starting with whatever the previous test left applied must still end with a theme, which is
+	/// the property that stops the blanket-tint approach coming back as "no theme at all".
+	/// </summary>
+	[TestMethod]
+	public void TheEditorAlwaysRunsUnderSomeTheme()
+	{
+		harness.Editor.Options.ThemeName = string.Empty;
+
+		harness.Editor.OnStart();
+		harness.App.Step(3);
+
+		Assert.IsFalse(string.IsNullOrEmpty(EditorTheme.CurrentName), "The editor drew a frame with no theme applied.");
+	}
+}

--- a/SchemaEditor.Test/TreeRowWidthTests.cs
+++ b/SchemaEditor.Test/TreeRowWidthTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using ktsu.ImGui.App.Testing;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// How wide a tree row is drawn.
+/// </summary>
+/// <remarks>
+/// The rows shared one fixed width, and ImGui clips a button's label to its frame, so the longest
+/// label in the tree - "Code Generators (0)" - was drawn without its count. The width is a minimum
+/// now: short labels still line up as a column, and a long one grows to fit.
+/// </remarks>
+[TestClass]
+public sealed class TreeRowWidthTests
+{
+	private EditorHarness harness = null!;
+
+	[TestCleanup]
+	public void StopEditor() => harness?.Dispose();
+
+	private int WidthOf(string item)
+	{
+		harness.StepUntil(() => harness.App.Probe.Matches(item).Count > 0, $"'{item}' appearing");
+		Rectangle rect = harness.App.Probe.Rect(item) ?? throw new AssertFailedException($"'{item}' was not recorded.");
+		return rect.Width;
+	}
+
+	/// <summary>
+	/// The four tree headings are drawn from the same code with labels of very different lengths,
+	/// which is where the clipping showed up.
+	/// </summary>
+	[TestMethod]
+	public void ALongerHeadingIsDrawnWiderThanSpareColumnWidthAllows()
+	{
+		// Narrow, because the column is 15% of the display width: at a wide display every heading
+		// fits and there is nothing to prove. This is the shape of window the clipping was
+		// reported from.
+		harness = EditorHarness.Start(new HarnessOptions { Width = 700, Height = 600 });
+		harness.Editor.CurrentSchema = new Schema();
+
+		Assert.IsTrue(
+			WidthOf("RootCode Generators") > WidthOf("RootEnums"),
+			"'Code Generators (0)' is the longest heading in the tree; drawn at the same width as 'Enums (0)' it loses its count.");
+	}
+
+	[TestMethod]
+	public void ALongerClassNameIsDrawnWider()
+	{
+		harness = EditorHarness.Start();
+		Schema schema = new();
+		schema.AddClass("A".As<ClassName>());
+		schema.AddClass("AClassNameLongEnoughToNeedMoreRoomThanTheColumnGives".As<ClassName>());
+		harness.Editor.CurrentSchema = schema;
+
+		Assert.IsTrue(
+			WidthOf("BtnAClassNameLongEnoughToNeedMoreRoomThanTheColumnGives") > WidthOf("BtnA"),
+			"A class name longer than the column was clipped instead of widening its row.");
+	}
+
+	/// <summary>
+	/// The width is a minimum, not a per-row measurement: rows whose labels both fit still line up,
+	/// or the tree would be a ragged edge.
+	/// </summary>
+	[TestMethod]
+	public void ShortLabelsShareOneColumnWidth()
+	{
+		harness = EditorHarness.Start();
+		Schema schema = new();
+		schema.AddClass("A".As<ClassName>());
+		schema.AddClass("Bee".As<ClassName>());
+		harness.Editor.CurrentSchema = schema;
+
+		Assert.AreEqual(WidthOf("BtnA"), WidthOf("BtnBee"));
+	}
+}

--- a/SchemaEditor.Test/ValidationMarkingTests.cs
+++ b/SchemaEditor.Test/ValidationMarkingTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using ktsu.ImGui.App.Testing;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+/// <summary>
+/// That an element carrying a validation error is actually drawn in the error colour.
+/// </summary>
+/// <remarks>
+/// This is what the theme change was for. Colour is the editor's way of saying "this one is
+/// wrong", and it only says anything if the rest of the interface is not already wearing it - the
+/// editor used to tint every widget with the primary colour, leaving the marking nothing to stand
+/// out against.
+///
+/// Measured on screen rather than through the model, because the model side is covered elsewhere
+/// and it is the drawing that this is about. The default theme is VSCode Dark, whose error colour
+/// is red; a test that pinned no theme could not ask this question.
+/// </remarks>
+[TestClass]
+public sealed class ValidationMarkingTests
+{
+	private EditorHarness harness = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+		harness.Editor.Options.ThemeName = string.Empty;
+		harness.Editor.OnStart();
+	}
+
+	[TestCleanup]
+	public void StopEditor() => harness.Dispose();
+
+	/// <summary>
+	/// Counts pixels that are clearly red rather than any particular shade, so the test does not
+	/// depend on the exact value the theme picks for an error.
+	/// </summary>
+	private int RedPixels()
+	{
+		CapturedFrame frame = harness.App.Capture();
+		int count = 0;
+
+		for (int y = 0; y < frame.Height; y++)
+		{
+			for (int x = 0; x < frame.Width; x++)
+			{
+				Rgba32 pixel = frame.GetPixel(x, y);
+				if (pixel.R > 120 && pixel.R > pixel.G + 40 && pixel.R > pixel.B + 40)
+				{
+					count++;
+				}
+			}
+		}
+
+		return count;
+	}
+
+	private void Revalidate()
+	{
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+		harness.App.Step(4);
+	}
+
+	[TestMethod]
+	public void AMemberWhoseTypeIsBrokenIsDrawnInTheErrorColour()
+	{
+		Schema schema = new();
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		SchemaMember id = user.AddMember("Id".As<MemberName>())!;
+		id.SetType(new SchemaTypes.Int());
+
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.EditClass(user);
+		Revalidate();
+
+		Assert.AreEqual(0, harness.Editor.Diagnostics.Count, "This schema was supposed to start clean.");
+		int before = RedPixels();
+
+		// Point the member at a class that is not there: an error, reported against the member.
+		id.SetType(new SchemaTypes.Object() { ClassName = "NoSuchClass".As<ClassName>() });
+		Revalidate();
+
+		Assert.IsNotNull(harness.Editor.GetIssueFor(id), "The broken reference should have been reported against the member.");
+		Assert.IsTrue(RedPixels() > before, "The member carrying an error was drawn no differently from one without.");
+	}
+
+	/// <summary>
+	/// The menu bar carries the counts as well, so a schema's health is visible without opening the
+	/// diagnostics tab.
+	/// </summary>
+	[TestMethod]
+	public void TheMenuBarIsDrawnInTheErrorColourWhileThereAreErrors()
+	{
+		Schema schema = new();
+		schema.AddClass("User".As<ClassName>());
+		harness.Editor.CurrentSchema = schema;
+		Revalidate();
+		int before = RedPixels();
+
+		// An empty class name is an error, and nothing is selected, so the only thing that can
+		// draw in the error colour is the summary in the menu bar.
+		schema.AddClass(new ClassName());
+		Revalidate();
+
+		Assert.IsTrue(harness.Editor.Diagnostics.Count > 0);
+		Assert.IsTrue(RedPixels() > before, "The menu bar did not report the errors in the error colour.");
+	}
+}

--- a/SchemaEditor/AppData.cs
+++ b/SchemaEditor/AppData.cs
@@ -26,6 +26,15 @@ internal sealed class AppData : AppData<AppData>
 	public Popups Popups { get; set; } = new();
 
 	/// <summary>
+	/// Gets or sets the name of the ktsu.ThemeProvider theme to apply, or empty for the default.
+	/// </summary>
+	/// <remarks>
+	/// Stored by name rather than as colours so a theme that is revised upstream is picked up
+	/// rather than frozen at whatever it looked like when the setting was written.
+	/// </remarks>
+	public string ThemeName { get; set; } = string.Empty;
+
+	/// <summary>
 	/// Gets or sets the most recently opened schema files, newest first.
 	/// </summary>
 	/// <remarks>

--- a/SchemaEditor/ButtonTree.cs
+++ b/SchemaEditor/ButtonTree.cs
@@ -40,6 +40,20 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 		public Action<ImGuiWidgets.Tree>? OnTreeEnd { get; set; }
 	}
 
+	/// <summary>
+	/// The width to draw a tree row at.
+	/// </summary>
+	/// <remarks>
+	/// The rows share a width so the tree reads as a column rather than a ragged edge, but that
+	/// width has to be a minimum rather than a fixed size: ImGui clips a button's label to its
+	/// frame, so "Code Generators (0)" - the longest label in the tree - lost its count entirely
+	/// at the sizes the editor actually runs at.
+	/// </remarks>
+	/// <param name="text">The label that has to fit.</param>
+	/// <returns>The column width, or the width the text needs when that is more.</returns>
+	private static float RowWidth(string text) =>
+		MathF.Max(SchemaEditor.FieldWidth, ImGui.CalcTextSize(text).X + (ImGui.GetStyle().FramePadding.X * 2));
+
 	internal static void ShowTree(string id, string text, IEnumerable<TItem> items) => ShowTree(id, text, items, new(), null);
 	internal static void ShowTree(string id, string text, IEnumerable<TItem> items, Config config, ImGuiWidgets.Tree? parent)
 	{
@@ -50,7 +64,8 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 		{
 			using (Button.Alignment.Left())
 			{
-				ImGui.Button(text, new(SchemaEditor.FieldWidth, 0));
+				ImGui.Button(text, new(RowWidth(text), 0));
+				ImGuiProbes.MarkItem($"Root{id}");
 			}
 
 			ImGui.SameLine();
@@ -111,13 +126,9 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 				SchemaValidationIssue? issue = config.GetIssue?.Invoke(item);
 
 				using (Button.Alignment.Left())
-				using (issue is null
-					? null
-					: Theme.FromColor(issue.Severity == SchemaValidationSeverity.Error
-						? Palette.Semantic.Error
-						: Palette.Semantic.Warning))
+				using (issue is null ? null : EditorTheme.Severity(issue.Severity))
 				{
-					ImGui.Button($"{buttonText}##Btn{itemId}", new(SchemaEditor.FieldWidth, 0));
+					ImGui.Button($"{buttonText}##Btn{itemId}", new(RowWidth(buttonText), 0));
 
 					// Every tree row in the editor is drawn here, so marking it here is what lets a
 					// test address any of them - a class, a member, an enum value, a data source -

--- a/SchemaEditor/CodeGeneratorPanel.cs
+++ b/SchemaEditor/CodeGeneratorPanel.cs
@@ -6,7 +6,6 @@ using System.Numerics;
 
 using Hexa.NET.ImGui;
 
-using ktsu.ImGui.Styler;
 using ktsu.Schema.Generation;
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
@@ -129,7 +128,7 @@ internal sealed class CodeGeneratorPanel(SchemaEditor schemaEditor)
 	{
 		if (!schema.CanResolvePaths)
 		{
-			using (Theme.FromColor(Palette.Semantic.Warning))
+			using (EditorTheme.Warning())
 			{
 				ImGui.TextUnformatted("Save the schema before generating: output paths are relative to it.");
 			}

--- a/SchemaEditor/EditorHost.cs
+++ b/SchemaEditor/EditorHost.cs
@@ -36,7 +36,7 @@ internal static class EditorHost
 			// The startup title only; SchemaEditor keeps it current from there, showing the open
 			// document and whether it has unsaved changes.
 			Title = nameof(SchemaEditor),
-			OnStart = SchemaEditor.OnStart,
+			OnStart = editor.OnStart,
 			OnUpdate = editor.OnTick,
 			OnRender = editor.OnRender,
 			OnAppMenu = editor.OnMenu,

--- a/SchemaEditor/EditorTheme.cs
+++ b/SchemaEditor/EditorTheme.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using ktsu.ImGui.Styler;
+using ktsu.Schema.Models;
+using ktsu.ThemeProvider;
+
+/// <summary>
+/// The application-wide look, as a ktsu.ThemeProvider theme.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A theme is applied once and then left alone. It is not the same thing as
+/// <see cref="Theme.FromColor"/>, which pushes one colour around one widget and is what marks an
+/// element carrying an error or a warning. The editor used to wrap every frame in
+/// <c>FromColor(Palette.Semantic.Primary)</c>, which tinted the whole interface with the primary
+/// colour and left an ordinary button indistinguishable from an emphasised one.
+/// </para>
+/// <para>
+/// Separate from <see cref="SchemaEditor"/> so that the registry and its types do not count
+/// against that class's coupling budget, which they otherwise push past the analyzer's limit.
+/// </para>
+/// </remarks>
+internal static class EditorTheme
+{
+	/// <summary>
+	/// The theme applied when the settings name none, or name one no longer registered.
+	/// </summary>
+	private const string DefaultThemeName = "VSCode Dark";
+
+	/// <summary>
+	/// Gets the name of the theme currently applied, or empty when none is.
+	/// </summary>
+	internal static string CurrentName => Theme.CurrentThemeName ?? string.Empty;
+
+	/// <summary>
+	/// Applies a theme by name, falling back when the name resolves to nothing.
+	/// </summary>
+	/// <remarks>
+	/// The default is resolved against the registry rather than hard-wired, so a theme leaving
+	/// ktsu.ThemeProvider degrades to another dark one. A registry with no themes at all leaves
+	/// ImGui's own styling in place, which is a readable neutral rather than something to fail on.
+	/// </remarks>
+	/// <param name="themeName">The theme to apply, or empty for the default.</param>
+	internal static void Apply(string themeName) =>
+		Theme.CurrentThemeName = Resolve(themeName) ?? Resolve(DefaultThemeName) ?? FirstDarkThemeName();
+
+	private static string? Resolve(string themeName) =>
+		!string.IsNullOrEmpty(themeName) && ThemeRegistry.FindTheme(themeName) is ThemeRegistry.ThemeInfo found
+			? found.Name
+			: null;
+
+	private static string? FirstDarkThemeName()
+	{
+		IReadOnlyList<ThemeRegistry.ThemeInfo> dark = ThemeRegistry.DarkThemes;
+		return dark.Count > 0 ? dark[0].Name : null;
+	}
+
+	/// <summary>
+	/// Scopes the colour that marks an element carrying a validation issue.
+	/// </summary>
+	/// <remarks>
+	/// One definition rather than the same severity ternary written out at each of the places an
+	/// issue is drawn - the tree row, the diagnostics list, the summary and the member row - so
+	/// they cannot drift apart.
+	/// </remarks>
+	/// <param name="severity">The severity to colour for.</param>
+	/// <returns>A scope that reverts the colour when disposed.</returns>
+	internal static ScopedThemeColor Severity(SchemaValidationSeverity severity) =>
+		severity == SchemaValidationSeverity.Error ? Error() : Warning();
+
+	/// <summary>
+	/// Scopes the colour for something that is wrong.
+	/// </summary>
+	internal static ScopedThemeColor Error() => Theme.FromColor(Palette.Semantic.Error);
+
+	/// <summary>
+	/// Scopes the colour for something that needs attention but is not wrong.
+	/// </summary>
+	internal static ScopedThemeColor Warning() => Theme.FromColor(Palette.Semantic.Warning);
+
+	/// <summary>
+	/// Draws the theme menu. Returns true when the user picked a different theme.
+	/// </summary>
+	internal static bool ShowMenu() => Theme.RenderThemeSelectorMenu();
+
+	/// <summary>
+	/// Draws the theme browser if it is open. Returns true when the user picked a different theme.
+	/// </summary>
+	internal static bool ShowBrowser() => Theme.RenderThemeSelector();
+}

--- a/SchemaEditor/EditorTheme.cs
+++ b/SchemaEditor/EditorTheme.cs
@@ -38,24 +38,19 @@ internal static class EditorTheme
 	/// Applies a theme by name, falling back when the name resolves to nothing.
 	/// </summary>
 	/// <remarks>
-	/// The default is resolved against the registry rather than hard-wired, so a theme leaving
-	/// ktsu.ThemeProvider degrades to another dark one. A registry with no themes at all leaves
-	/// ImGui's own styling in place, which is a readable neutral rather than something to fail on.
+	/// Both names are looked up rather than trusted, because the saved one was written by an
+	/// earlier build and the theme may since have been renamed or dropped. Neither resolving
+	/// leaves ImGui's own styling in place, which is a readable neutral rather than something to
+	/// fail on.
 	/// </remarks>
 	/// <param name="themeName">The theme to apply, or empty for the default.</param>
 	internal static void Apply(string themeName) =>
-		Theme.CurrentThemeName = Resolve(themeName) ?? Resolve(DefaultThemeName) ?? FirstDarkThemeName();
+		Theme.CurrentThemeName = Resolve(themeName) ?? Resolve(DefaultThemeName);
 
 	private static string? Resolve(string themeName) =>
 		!string.IsNullOrEmpty(themeName) && ThemeRegistry.FindTheme(themeName) is ThemeRegistry.ThemeInfo found
 			? found.Name
 			: null;
-
-	private static string? FirstDarkThemeName()
-	{
-		IReadOnlyList<ThemeRegistry.ThemeInfo> dark = ThemeRegistry.DarkThemes;
-		return dark.Count > 0 ? dark[0].Name : null;
-	}
 
 	/// <summary>
 	/// Scopes the colour that marks an element carrying a validation issue.
@@ -89,4 +84,9 @@ internal static class EditorTheme
 	/// Draws the theme browser if it is open. Returns true when the user picked a different theme.
 	/// </summary>
 	internal static bool ShowBrowser() => Theme.RenderThemeSelector();
+
+	/// <summary>
+	/// Opens the theme browser. The menu does this for the user; a test does it directly.
+	/// </summary>
+	internal static void OpenBrowser() => Theme.ShowThemeSelector();
 }

--- a/SchemaEditor/SchemaEditor.Diagnostics.cs
+++ b/SchemaEditor/SchemaEditor.Diagnostics.cs
@@ -9,7 +9,6 @@ using System.Linq;
 
 using Hexa.NET.ImGui;
 
-using ktsu.ImGui.Styler;
 using ktsu.Schema.Models;
 
 /// <summary>
@@ -81,7 +80,7 @@ public partial class SchemaEditor
 		int warnings = WarningCount;
 
 		ImGui.Separator();
-		using (Theme.FromColor(errors > 0 ? Palette.Semantic.Error : Palette.Semantic.Warning))
+		using (EditorTheme.Severity(errors > 0 ? SchemaValidationSeverity.Error : SchemaValidationSeverity.Warning))
 		{
 			ImGui.TextUnformatted(FormatSummary(errors, warnings));
 		}
@@ -122,7 +121,7 @@ public partial class SchemaEditor
 	{
 		bool isError = issue.Severity == SchemaValidationSeverity.Error;
 
-		using (Theme.FromColor(isError ? Palette.Semantic.Error : Palette.Semantic.Warning))
+		using (EditorTheme.Severity(issue.Severity))
 		{
 			ImGui.TextUnformatted(isError ? "Error" : "Warning");
 		}

--- a/SchemaEditor/SchemaEditor.Panels.cs
+++ b/SchemaEditor/SchemaEditor.Panels.cs
@@ -10,7 +10,6 @@ using System.Numerics;
 using Hexa.NET.ImGui;
 
 using ktsu.ImGui.Probes;
-using ktsu.ImGui.Styler;
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
 using ktsu.Semantics.Paths;
@@ -395,7 +394,7 @@ public partial class SchemaEditor
 		}
 
 		ImGui.SameLine();
-		using (Theme.FromColor(issue.Severity == SchemaValidationSeverity.Error ? Palette.Semantic.Error : Palette.Semantic.Warning))
+		using (EditorTheme.Severity(issue.Severity))
 		{
 			ImGui.TextUnformatted(issue.Severity == SchemaValidationSeverity.Error ? "!" : "?");
 		}

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 
 using Hexa.NET.ImGui;
 
-using ktsu.ImGui.Styler;
 using ktsu.ImGui.Widgets;
 using ktsu.IntervalAction;
 using ktsu.Schema.Models;
@@ -103,11 +102,22 @@ public partial class SchemaEditor
 		}
 	}
 
-	internal static void OnStart()
+	/// <summary>
+	/// Applies the saved theme once ImGui exists to receive it.
+	/// </summary>
+	/// <remarks>
+	/// A theme has to be applied here rather than in the constructor: it writes ImGui's style
+	/// colours, and there is no ImGui context until the application has started.
+	/// </remarks>
+	internal void OnStart() => EditorTheme.Apply(Options.ThemeName);
+
+	/// <summary>
+	/// Notes a theme the user chose, so it is there again next time.
+	/// </summary>
+	private void RecordThemeChoice()
 	{
-		// Set up initial window state if needed
-		// Note: Window state handling may need to be implemented differently
-		// with the current version of ImGuiApp
+		Options.ThemeName = EditorTheme.CurrentName;
+		QueueSaveOptions();
 	}
 
 	private void DividerResized(ImGuiWidgets.DividerContainer container)
@@ -215,10 +225,18 @@ public partial class SchemaEditor
 	{
 		// Stashed for the parameterless tab content delegates (the Class Graph needs the frame delta).
 		currentDeltaTime = dt;
-		using (Theme.FromColor(Palette.Semantic.Primary))
+
+		// No theme colour is pushed around the whole application. Theme.FromColor is a scoped
+		// colour for one widget - it is what marks an element that has an error or a warning - and
+		// wrapping every frame in the primary colour tinted the entire interface with it, leaving
+		// an ordinary button indistinguishable from an emphasised one. The application-wide look
+		// belongs to the ktsu.ThemeProvider theme applied in OnStart.
+		DividerContainerCols.Tick(dt);
+		Popups.Update();
+
+		if (EditorTheme.ShowBrowser())
 		{
-			DividerContainerCols.Tick(dt);
-			Popups.Update();
+			RecordThemeChoice();
 		}
 	}
 
@@ -253,6 +271,12 @@ public partial class SchemaEditor
 	{
 		ShowFileMenu();
 		ShowEditMenu();
+
+		if (EditorTheme.ShowMenu())
+		{
+			RecordThemeChoice();
+		}
+
 		ShowDocumentStatus();
 	}
 
@@ -378,7 +402,7 @@ public partial class SchemaEditor
 
 		if (string.IsNullOrEmpty(CurrentSchemaPath))
 		{
-			using (Theme.FromColor(Palette.Semantic.Error))
+			using (EditorTheme.Error())
 			{
 				ImGui.TextUnformatted("Schema has not been saved. Save it before configuring relative paths.");
 

--- a/SchemaEditor/SchemaEditor.csproj
+++ b/SchemaEditor/SchemaEditor.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="ktsu.IntervalAction" />
     <PackageReference Include="ktsu.Keybinding.Core" />
     <PackageReference Include="ktsu.Semantics.Paths" />
+    <PackageReference Include="ktsu.ThemeProvider" />
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="ktsu.UndoRedo.Core" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" />

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -96,6 +96,9 @@ rows' controls apart the same way `PushID` does for ImGui itself. A test then cl
 
 Frames are advanced by the test, never by wall-clock time — `Step(n)` for a fixed number and
 `StepUntil(condition, budget)` for a wait — so a loaded runner is slower rather than flakier.
+`App.Capture().SavePng(path)` writes the rendered frame to disk, which is how a visual change is
+checked without a display: render before, render after, and look at the two images.
+
 Where a regression is only visible on screen,
 `App.Capture()` gives the rendered pixels: `TwoRowsSharingALabelDoNotShareABuffer` compares one
 row's pixels before and during an edit of its sibling, which is the only place the shared-buffer

--- a/docs/features/schema-editor.md
+++ b/docs/features/schema-editor.md
@@ -62,6 +62,17 @@ The layout is split into two resizable panels. Panel sizes are persisted across 
 - **Save** - Saves the current schema (prompts for location if unsaved)
 - **Open Externally** - Opens the schema file's directory in the system file explorer
 
+### Theme Menu
+
+Opens a browser of the themes ktsu.ThemeProvider registers - Catppuccin, Dracula, Everforest,
+Gruvbox, Kanagawa, Monokai, Nord, One Dark, Tokyo Night, VSCode and others, in dark and light
+variants. The editor starts on VSCode Dark, and the choice is remembered by name so a theme revised
+upstream is picked up rather than frozen at whatever it looked like when the setting was written.
+
+Colour carries meaning elsewhere in the editor, so the theme deliberately does not: an element with
+a validation error or warning is tinted, and everything else takes the theme's own colours. Marking
+every widget would leave nothing for the marking to stand out against.
+
 ### Left Panel - Schema Tree
 
 The left panel shows four collapsible tree sections:
@@ -117,6 +128,8 @@ The editor automatically persists:
 - Last selected class
 - Panel divider positions
 - Tree node expand/collapse state
+- Recently opened files
+- The selected theme
 
 These settings are stored via `ktsu.AppDataStorage` and restored on next launch.
 


### PR DESCRIPTION
Two things visible in a screenshot of the running editor.

## 1. Everything was blue

`OnRender` wrapped every frame in `Theme.FromColor(Palette.Semantic.Primary)`. `FromColor` is documented as a *scoped* colour for one widget — it is what marks an element carrying an error or a warning — so applying it to the whole frame tinted the entire interface with the primary colour and left an ordinary button looking exactly like an emphasised one. The application-wide look is what `ktsu.ThemeProvider` is for, and the editor had no theme at all.

So the editor now applies a real theme: read from settings on start, defaulting to **VSCode Dark**, with a **Theme** menu that opens the registry's browser (38 themes — Catppuccin, Dracula, Everforest, Gruvbox, Kanagawa, Monokai, Nord, One Dark, Tokyo Night, VSCode…) and remembers the choice. The saved name is resolved against the registry rather than trusted, so a theme renamed or dropped upstream falls back instead of leaving the editor unstyled.

### Verified by rendering, not by assuming

`SchemaEditor.Test` renders through a software rasterizer with no display, so the change could be looked at rather than assumed. Capturing the same scene before and after:

- **Before** — the primary colour on every widget: the tree rows, the name field, the description box, the section headers and the member rows are all the same blue, and the red "Save Now" banner competes with them rather than standing out.
- **After** — themed neutrals with readable text, and the error banner is the only thing shouting.

`App.Capture().SavePng(path)` reproduces both; that is now documented in the development guide as the way to check a visual change headlessly.

### Where it lives

`EditorTheme` is a new type rather than more surface on `SchemaEditor`, because the registry's types push that class past `CA1506`'s coupling limit — the same budget `Program.cs` already warns about in its own doc comment.

It also became the one place that says how a validation issue is coloured. That severity ternary was written out four times (`ButtonTree`, the diagnostics list, the summary, the member row) and can no longer drift apart:

```csharp
internal static ScopedThemeColor Severity(SchemaValidationSeverity severity) =>
    severity == SchemaValidationSeverity.Error ? Error() : Warning();
```

## 2. "Code Generators (" lost its count

Tree rows were drawn at a fixed width — 15% of the display width — and ImGui clips a button's label to its frame. `"Code Generators (0)"` is the longest label in the tree, and at the window size this was reported from it did not fit. The width is a minimum now: short labels still line up as a column, a long one grows to fit.

The test starts the harness at 700px wide, because at the default 1280 every heading fits and there is nothing to prove — which is exactly why my first version of that test passed against the unfixed code. Reverting `RowWidth` to the fixed width fails both width tests; I checked.

## Tests

13 new tests, 395 total, 0 failures.

- **Theme resolution** — settings naming no theme get the default; a named theme is applied; a theme no longer in the registry falls back; the saved theme is applied on start; and the editor never draws a frame with no theme applied, which is the property that stops the blanket-tint approach returning as "no theme at all".
- **Choosing a theme** — the browser marks each of its cards, so three tests open it, click one, and check the theme is applied, reaches the settings, and comes back on the next start. The cards named are ones near the top of the grid: it scrolls, and a card below the fold is recorded at a position that has been clipped away, so clicking it hits the modal behind. Nord is the thirtieth card and that is exactly what happened to it first time.
- **The error colour** — measured on screen, because that is what this change was for. Point a member at a class that is not there and the member's row gains red pixels; add a class with an empty name and the menu bar's summary does. They count clearly-red pixels rather than an exact value, so they do not depend on the shade VSCode Dark picks.
- **Row width** — a longer heading and a longer class name are each drawn wider than the column, and short labels still share one width.

`EditorHarness.Start(HarnessOptions)` is new, so a test can choose the display size — which matters because the editor derives its column widths from it.

### Coverage

New-code coverage is 96.3%. The one line not covered is the severity colour inside `ShowDiagnostic`, which sits behind the Diagnostics tab; the tab bar comes from a widget library that does not record its tabs, so there is no name for a test to click — the same limitation that sends the class-graph tests through `WidgetHarness`.

The second commit exists because the first missed that: `EditorTheme` also had a third fallback (if neither the saved nor the default theme resolved, take the first dark theme in the registry) that no test could reach, since it needs `ktsu.ThemeProvider` to drop VSCode Dark. Removed rather than worked around — neither resolving now leaves ImGui's own styling, which the doc comment already called a readable neutral rather than a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc8o5zF3cmfCGjzWvQdGDE