### PR TITLE
Restore a data source or code generator where it was (#141)

### DIFF
--- a/Schema.Test/SchemaRootSetTests.cs
+++ b/Schema.Test/SchemaRootSetTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Tests;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+/// <summary>
+/// Covers <see cref="Schema.DataSourceSet"/> and <see cref="Schema.CodeGeneratorSet"/>, the ordered
+/// views that let a caller put a deleted data source or code generator back where it was.
+/// <see cref="Schema.RestoreDataSource"/> and <see cref="Schema.RestoreCodeGenerator"/> append, so
+/// without a position to move it to, undoing a delete would quietly reorder the schema - and order
+/// is part of its meaning, since it round-trips through the file and drives generated code.
+/// </summary>
+[TestClass]
+public class SchemaRootSetTests
+{
+	private static readonly string[] DataSourceSeed = ["Users", "Orders", "Products"];
+	private static readonly string[] CodeGeneratorSeed = ["CSharp", "Cpp", "Docs"];
+	private static readonly string[] WithoutOrders = ["Users", "Products"];
+	private static readonly string[] OrdersAppended = ["Users", "Products", "Orders"];
+	private static readonly string[] WithoutCpp = ["CSharp", "Docs"];
+	private static readonly string[] ProductsMovedToFront = ["Products", "Users", "Orders"];
+
+	private static Schema CreateSchema()
+	{
+		Schema schema = new();
+		foreach (string name in DataSourceSeed)
+		{
+			schema.AddDataSource(name.As<DataSourceName>());
+		}
+
+		foreach (string name in CodeGeneratorSeed)
+		{
+			schema.AddCodeGenerator(name.As<CodeGeneratorName>());
+		}
+
+		return schema;
+	}
+
+	private static string[] DataSourceNames(Schema schema) =>
+		[.. schema.DataSources.Select(d => d.Name.ToString())];
+
+	private static string[] CodeGeneratorNames(Schema schema) =>
+		[.. schema.CodeGenerators.Select(g => g.Name.ToString())];
+
+	[TestMethod]
+	public void TestTheDataSourceSetIsAViewInDeclarationOrder()
+	{
+		Schema schema = CreateSchema();
+
+		Assert.AreEqual(DataSourceSeed.Length, schema.DataSourceSet.Count);
+		string[] throughTheSet = [.. schema.DataSourceSet.Select(d => d.Name.ToString())];
+		CollectionAssert.AreEqual(DataSourceSeed, throughTheSet);
+		Assert.AreEqual(1, schema.DataSourceSet.IndexOf(schema.GetDataSource("Orders".As<DataSourceName>())!));
+	}
+
+	[TestMethod]
+	public void TestTheCodeGeneratorSetIsAViewInDeclarationOrder()
+	{
+		Schema schema = CreateSchema();
+
+		Assert.AreEqual(CodeGeneratorSeed.Length, schema.CodeGeneratorSet.Count);
+		string[] throughTheSet = [.. schema.CodeGeneratorSet.Select(g => g.Name.ToString())];
+		CollectionAssert.AreEqual(CodeGeneratorSeed, throughTheSet);
+		Assert.AreEqual(1, schema.CodeGeneratorSet.IndexOf(schema.GetCodeGenerator("Cpp".As<CodeGeneratorName>())!));
+	}
+
+	/// <summary>
+	/// The restore on its own is what an undo would do without the set; asserting the appended
+	/// order first is what makes the move afterwards the thing being tested.
+	/// </summary>
+	[TestMethod]
+	public void TestADataSourceCanBeRestoredWhereItWas()
+	{
+		Schema schema = CreateSchema();
+		DataSource orders = schema.GetDataSource("Orders".As<DataSourceName>())!;
+		int index = schema.DataSourceSet.IndexOf(orders);
+
+		Assert.IsTrue(orders.TryRemove());
+		CollectionAssert.AreEqual(WithoutOrders, DataSourceNames(schema));
+
+		Assert.IsTrue(schema.RestoreDataSource(orders));
+		CollectionAssert.AreEqual(OrdersAppended, DataSourceNames(schema));
+
+		Assert.IsTrue(schema.DataSourceSet.Move(orders, index));
+		CollectionAssert.AreEqual(DataSourceSeed, DataSourceNames(schema));
+	}
+
+	[TestMethod]
+	public void TestACodeGeneratorCanBeRestoredWhereItWas()
+	{
+		Schema schema = CreateSchema();
+		SchemaCodeGenerator cpp = schema.GetCodeGenerator("Cpp".As<CodeGeneratorName>())!;
+		int index = schema.CodeGeneratorSet.IndexOf(cpp);
+
+		Assert.IsTrue(cpp.TryRemove());
+		CollectionAssert.AreEqual(WithoutCpp, CodeGeneratorNames(schema));
+
+		Assert.IsTrue(schema.RestoreCodeGenerator(cpp));
+		Assert.IsTrue(schema.CodeGeneratorSet.Move(cpp, index));
+		CollectionAssert.AreEqual(CodeGeneratorSeed, CodeGeneratorNames(schema));
+	}
+
+	/// <summary>
+	/// The sets write through to the collections the schema serializes rather than to a copy, so a
+	/// repositioned element stays repositioned in the file.
+	/// </summary>
+	[TestMethod]
+	public void TestARepositionedDataSourceSurvivesARoundTrip()
+	{
+		Schema schema = CreateSchema();
+		Assert.IsTrue(schema.DataSourceSet.Move(schema.GetDataSource("Products".As<DataSourceName>())!, 0));
+
+		string json = SchemaSerializer.Serialize(schema);
+		Assert.IsTrue(SchemaSerializer.TryDeserialize(json, out Schema? reloaded));
+		Assert.IsNotNull(reloaded);
+
+		CollectionAssert.AreEqual(ProductsMovedToFront, DataSourceNames(reloaded));
+	}
+}

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -112,6 +112,18 @@ public partial class Schema : ISchema
 	[JsonIgnore]
 	public SchemaChildSet<SchemaEnum, EnumName> EnumSet => new(EnumsInternal);
 
+	/// <summary>
+	/// Gets the schema's data sources as a name-indexed, order-preserving set.
+	/// </summary>
+	[JsonIgnore]
+	public SchemaChildSet<DataSource, DataSourceName> DataSourceSet => new(DataSourcesInternal);
+
+	/// <summary>
+	/// Gets the schema's code generators as a name-indexed, order-preserving set.
+	/// </summary>
+	[JsonIgnore]
+	public SchemaChildSet<SchemaCodeGenerator, CodeGeneratorName> CodeGeneratorSet => new(CodeGeneratorsInternal);
+
 	/// <remarks>
 	/// Explicit because the contract's element type is <see cref="ISchemaClass"/>; the covariance
 	/// of <see cref="ISchemaChildSet{TValue, TName}"/> makes it the same object.

--- a/SchemaEditor.Test/TreeContextMenuTests.cs
+++ b/SchemaEditor.Test/TreeContextMenuTests.cs
@@ -106,27 +106,53 @@ public sealed class TreeContextMenuTests
 		AssertEnums("Colour", "Size");
 	}
 
-	/// <summary>
-	/// Data sources and code generators are deleted the same way, but their restore does not
-	/// preserve position: the schema exposes an ordered set for classes and enums and not for
-	/// these two, so the editor has nothing to move them back with. See the note in the roadmap.
-	/// </summary>
+	private void AddDataSources(params string[] names)
+	{
+		foreach (string name in names)
+		{
+			schema.AddDataSource(name.As<DataSourceName>());
+		}
+
+		harness.Editor.CurrentSchema = schema;
+	}
+
+	private void AssertDataSources(params string[] expected)
+	{
+		string[] actual = [.. schema.DataSources.Select(d => d.Name.ToString())];
+		CollectionAssert.AreEqual(expected, actual, $"Data sources were [{string.Join(", ", actual)}].");
+	}
+
 	[TestMethod]
 	public void DeletingADataSourceRemovesIt()
 	{
-		schema.AddDataSource("Users".As<DataSourceName>());
-		harness.Editor.CurrentSchema = schema;
+		AddDataSources("Users");
 
 		ChooseFromContextMenu("BtnUsers", "DeleteUsers");
 
 		Assert.IsNull(schema.GetDataSource("Users".As<DataSourceName>()));
 	}
 
+	/// <summary>
+	/// Deleted from the middle, because appending on restore would put it back in the right set
+	/// but the wrong place - and at either end that is indistinguishable from doing it correctly.
+	/// </summary>
+	[TestMethod]
+	public void UndoingADataSourceDeleteBringsItBackWhereItWas()
+	{
+		AddDataSources("Users", "Orders", "Products");
+
+		ChooseFromContextMenu("BtnOrders", "DeleteOrders");
+		AssertDataSources("Users", "Products");
+
+		harness.Editor.UndoRedo.Undo();
+
+		AssertDataSources("Users", "Orders", "Products");
+	}
+
 	[TestMethod]
 	public void RenamingADataSourceChangesItsName()
 	{
-		schema.AddDataSource("Users".As<DataSourceName>());
-		harness.Editor.CurrentSchema = schema;
+		AddDataSources("Users");
 
 		ChooseFromContextMenu("BtnUsers", "RenameUsers");
 		harness.TypeInto("input/field", "People");
@@ -135,11 +161,26 @@ public sealed class TreeContextMenuTests
 		Assert.IsNotNull(schema.GetDataSource("People".As<DataSourceName>()));
 	}
 
+	private void AddCodeGenerators(params string[] names)
+	{
+		foreach (string name in names)
+		{
+			schema.AddCodeGenerator(name.As<CodeGeneratorName>());
+		}
+
+		harness.Editor.CurrentSchema = schema;
+	}
+
+	private void AssertCodeGenerators(params string[] expected)
+	{
+		string[] actual = [.. schema.CodeGenerators.Select(g => g.Name.ToString())];
+		CollectionAssert.AreEqual(expected, actual, $"Code generators were [{string.Join(", ", actual)}].");
+	}
+
 	[TestMethod]
 	public void DeletingACodeGeneratorRemovesIt()
 	{
-		schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>());
-		harness.Editor.CurrentSchema = schema;
+		AddCodeGenerators("CSharp");
 
 		ChooseFromContextMenu("BtnCSharp", "DeleteCSharp");
 
@@ -147,10 +188,22 @@ public sealed class TreeContextMenuTests
 	}
 
 	[TestMethod]
+	public void UndoingACodeGeneratorDeleteBringsItBackWhereItWas()
+	{
+		AddCodeGenerators("CSharp", "Cpp", "Docs");
+
+		ChooseFromContextMenu("BtnCpp", "DeleteCpp");
+		AssertCodeGenerators("CSharp", "Docs");
+
+		harness.Editor.UndoRedo.Undo();
+
+		AssertCodeGenerators("CSharp", "Cpp", "Docs");
+	}
+
+	[TestMethod]
 	public void RenamingACodeGeneratorChangesItsName()
 	{
-		schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>());
-		harness.Editor.CurrentSchema = schema;
+		AddCodeGenerators("CSharp");
 
 		ChooseFromContextMenu("BtnCSharp", "RenameCSharp");
 		harness.TypeInto("input/field", "CSharpPocos");

--- a/SchemaEditor/TreeCodeGenerator.cs
+++ b/SchemaEditor/TreeCodeGenerator.cs
@@ -54,10 +54,16 @@ internal sealed class TreeCodeGenerator(SchemaEditor schemaEditor)
 					ImGuiProbes.MarkItem($"Delete{captured.Name}");
 					if (deleteChosen)
 					{
+						// Restored where it was rather than appended; see DeleteMember in the panel.
+						int index = schema.CodeGeneratorSet.IndexOf(captured);
 						schemaEditor.Execute(new DelegateCommand(
 							$"Delete Code Generator '{captured.Name}'",
 							() => captured.TryRemove(),
-							() => schema.RestoreCodeGenerator(captured),
+							() =>
+							{
+								schema.RestoreCodeGenerator(captured);
+								schema.CodeGeneratorSet.Move(captured, index);
+							},
 							ChangeType.Delete));
 					}
 				},

--- a/SchemaEditor/TreeDataSource.cs
+++ b/SchemaEditor/TreeDataSource.cs
@@ -54,10 +54,16 @@ internal sealed class TreeDataSource(SchemaEditor schemaEditor)
 					ImGuiProbes.MarkItem($"Delete{captured.Name}");
 					if (deleteChosen)
 					{
+						// Restored where it was rather than appended; see DeleteMember in the panel.
+						int index = schema.DataSourceSet.IndexOf(captured);
 						schemaEditor.Execute(new DelegateCommand(
 							$"Delete Data Source '{captured.Name}'",
 							() => captured.TryRemove(),
-							() => schema.RestoreDataSource(captured),
+							() =>
+							{
+								schema.RestoreDataSource(captured);
+								schema.DataSourceSet.Move(captured, index);
+							},
 							ChangeType.Delete));
 					}
 				},

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,6 @@ substantial items:
 
 | Issue | Work | Why it is not done |
 | --- | --- | --- |
-| [#110](https://github.com/ktsu-dev/Schema/issues/110) | Implement or delete the unused `Schema.Contracts` API | Needs a decision from the project owner; deleting is a breaking change |
 | [#126](https://github.com/ktsu-dev/Schema/issues/126) | Generated data editors | Builds on the generator architecture |
 | [#127](https://github.com/ktsu-dev/Schema/issues/127) | Generated data migrations | Needs a schema diff, which does not exist yet |
 
@@ -118,10 +117,9 @@ worth testing, not of whether it can be.
 
 | Order | Work item | Effort | Rationale |
 | ----- | --- | --- | --- |
-| 1 | Decide [#110](https://github.com/ktsu-dev/Schema/issues/110): implement or delete `Schema.Contracts` | S | A decision, not a build. It is public API on a published package that nothing implements, and `docs/examples/dependency-injection.md` documents it as though it works |
-| 2 | [#126](https://github.com/ktsu-dev/Schema/issues/126): generated data editors | L | The first thing the data source binding was for |
-| 3 | [#127](https://github.com/ktsu-dev/Schema/issues/127): generated migrations | L | Needs a schema diff first; the largest remaining design problem |
-| 4 | Editor packaging and the v2.0 milestone | M | Ship it |
+| 1 | [#126](https://github.com/ktsu-dev/Schema/issues/126): generated data editors | L | The first thing the data source binding was for |
+| 2 | [#127](https://github.com/ktsu-dev/Schema/issues/127): generated migrations | L | Needs a schema diff first; the largest remaining design problem |
+| 3 | Editor packaging and the v2.0 milestone | M | Ship it |
 
 ## Decisions
 
@@ -138,10 +136,11 @@ Made while implementing, and open to revision:
 
 8. **A deleted element is restored where it was.** Undoing a delete puts the element back at the
    index it was removed from rather than at the end, because order is part of the schema's meaning:
-   it is the declaration order generated code uses, and it round-trips through the file. This is
-   done for classes, enums and members. Data sources and code generators still restore at the end,
-   because `Schema` exposes an ordered set (`ClassSet`, `EnumSet`) for the first two and not for
-   the other two, so the editor has nothing to reposition them with.
+   it is the declaration order generated code uses, and it round-trips through the file. This holds
+   for classes, enums, members, data sources and code generators. `Restore*` still appends — the
+   position is the caller's to remember — so `Schema` exposes an ordered set for each root
+   collection (`ClassSet`, `EnumSet`, `DataSourceSet`, `CodeGeneratorSet`) to move the element back
+   with ([#141](https://github.com/ktsu-dev/Schema/issues/141)).
 
 5. **Renames cascade.** Renaming a class or enum repoints every reference to it, rather than being
    blocked while references exist or allowed to dangle. It is the only option that neither loses


### PR DESCRIPTION
Closes #141.

## The bug

`Schema.RestoreDataSource` and `RestoreCodeGenerator` append. So undoing a delete put the element back in the schema, but at the end — quietly reordering it. Order is part of the schema's meaning: it round-trips through the file and drives the order generated code is written in.

Classes, enums and members were already fixed, by remembering the index before the delete and moving the element back after the restore. Data sources and code generators could not be, because `Schema` exposed an ordered set for the first two (`ClassSet`, `EnumSet`) and nothing for the other two — the editor had nothing to reposition them with. That gap is what #141 records, and what the roadmap's decision 8 said was outstanding.

## The fix

`Schema` now exposes `DataSourceSet` and `CodeGeneratorSet`, mirroring the existing pair exactly:

```csharp
public SchemaChildSet<DataSource, DataSourceName> DataSourceSet => new(DataSourcesInternal);
public SchemaChildSet<SchemaCodeGenerator, CodeGeneratorName> CodeGeneratorSet => new(CodeGeneratorsInternal);
```

Additive public API — read-through views over the same collections the schema already serializes, so there is no second copy to diverge and no change to the on-disk format. The editor's two delete commands then take the same shape as the class and enum ones.

### A note on the API decision

I raised this on #141 as the owner's call, because it puts new surface on a published package. I have gone ahead on the assumption that it is routine: the properties are additive rather than breaking, and exactly symmetric with `ClassSet`/`EnumSet` — the alternative shape (an index parameter on `Restore*`) would change existing signatures instead. If you would rather have that shape, say so and I will rework it.

## Tests

Five in `Schema.Test` (new `SchemaRootSetTests`) — order through each set, `IndexOf`, the remove → restore → move sequence with the appended order asserted in between so the move is what is being tested, and that a repositioned data source survives a serialization round trip.

Two in `SchemaEditor.Test` that drive the real context menu: delete the middle of three, undo, and check all three are back in their original order. Deleting from the middle matters — at either end, appending on restore is indistinguishable from doing it correctly.

Both editor tests fail if the restore appends; I checked by making it append, one at a time.

`304` library tests and `98` editor tests, `0` failures.

## Also

Two stale entries in `docs/ROADMAP.md`, found while updating decision 8:

- #110 was listed both as outstanding work and as the number-one thing to decide next, but it was closed by #129 back in August.
- Decision 8 said data sources and code generators still restore at the end. It now describes what this PR makes true, and says why `Restore*` still appends — the position is the caller's to remember.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jc8o5zF3cmfCGjzWvQdGDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jc8o5zF3cmfCGjzWvQdGDE)_