### PR TITLE
Rework the editor's menu bar, tree panel and class graph, and take ImGuiApp 3.16.8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,22 +8,22 @@
     <PackageVersion Include="ktsu.CodeBlocker" Version="2.0.2" />
     <PackageVersion Include="ktsu.DeepClone" Version="2.0.30" />
     <PackageVersion Include="ktsu.Extensions" Version="1.6.9" />
-    <PackageVersion Include="ktsu.ForceDirectedLayout" Version="3.16.6" />
+    <PackageVersion Include="ktsu.ForceDirectedLayout" Version="3.16.8" />
     <PackageVersion Include="ktsu.FuzzySearch" Version="1.2.39" />
-    <PackageVersion Include="ktsu.ImGui.Styler" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ThemeProvider" Version="3.0.14" />
+    <PackageVersion Include="ktsu.ImGui.Styler" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ThemeProvider" Version="3.0.15" />
     <PackageVersion Include="ktsu.IntervalAction" Version="1.3.41" />
     <PackageVersion Include="ktsu.Keybinding.Core" Version="1.0.41" />
     <PackageVersion Include="ktsu.UndoRedo.Core" Version="1.0.19" />
     <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.52" />
     <PackageVersion Include="ktsu.Semantics.Strings" Version="3.2.5" />
     <PackageVersion Include="ktsu.Semantics.Paths" Version="3.2.5" />
-    <PackageVersion Include="ktsu.ImGui.App" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ImGui.App.Testing" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ImGui.Popups" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ImGui.Probes" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.16.6" />
-    <PackageVersion Include="ktsu.ImGuiNodeEditor" Version="3.16.6" />
+    <PackageVersion Include="ktsu.ImGui.App" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ImGui.App.Testing" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ImGui.Popups" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ImGui.Probes" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.16.8" />
+    <PackageVersion Include="ktsu.ImGuiNodeEditor" Version="3.16.8" />
     <PackageVersion Include="ktsu.NodeGraph" Version="1.0.0" />
     <PackageVersion Include="ktsu.AppDataStorage" Version="1.16.50" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />

--- a/SchemaEditor.Test/ClassGraphTests.cs
+++ b/SchemaEditor.Test/ClassGraphTests.cs
@@ -2,6 +2,11 @@
 
 namespace ktsu.SchemaEditor.Test;
 
+using System.Linq;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
 using ktsu.ImGui.App.Testing;
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
@@ -46,6 +51,78 @@ public sealed class ClassGraphTests
 		CapturedFrame frame = harness.App.Capture();
 		Rgba32 background = harness.App.Options.ClearColor;
 		return frame.CountPixels(p => p != background);
+	}
+
+	/// <summary>
+	/// A class or enum that references nothing is drawn as a node like any other.
+	/// </summary>
+	/// <remarks>
+	/// Such an element becomes a node with no pins, and ImNodes ends a node's title bar by moving
+	/// the cursor to where the node's content starts. With no pin submitted after that, the node's
+	/// group closed on a cursor that had been moved and never used, which cost two things at once:
+	/// ImGui reported "code uses SetCursorPos() to extend window/parent boundaries" over the editor
+	/// every frame the graph was open, and the node's measured width grew by eight pixels a frame,
+	/// without limit, for as long as it was on screen.
+	///
+	/// The node is drawn by ktsu.ImGuiNodeEditor, so that is where the fix is: it submits an item
+	/// of its own for a node with no pins, from 3.16.8.
+	/// </remarks>
+	[TestMethod]
+	public void ANodeWithNoPinsIsDrawnWithoutErrorAndKeepsItsSize()
+	{
+		Schema schema = new();
+		schema.AddClass("Loner".As<ClassName>());
+
+		ClassGraphView graph = new();
+		harness.Draw = () => graph.Show(schema, 1f / 60f);
+
+		harness.App.Step(3);
+		Vector2 settled = graph.NodeSizes.First();
+
+		harness.App.Step(10);
+
+		// Read between frames: ImGui counts errors per frame and clears the count in the next one.
+		Assert.AreEqual(
+			0,
+			ImGui.GetCurrentContext().ErrorCountCurrentFrame,
+			"ImGui reported a usage error while the graph was drawing.");
+
+		Assert.AreEqual(
+			settled,
+			graph.NodeSizes.First(),
+			$"The node grew from {settled} while it sat there with nothing happening to it.");
+	}
+
+	[TestMethod]
+	public void TheGraphOpensAroundTheMiddleOfTheCanvas()
+	{
+		ClassGraphView graph = new();
+		Schema schema = BuildReferencingSchema();
+
+		Vector2 canvas = Vector2.Zero;
+		harness.Draw = () =>
+		{
+			canvas = ImGui.GetContentRegionAvail();
+			graph.Show(schema, 1f / 60f);
+		};
+
+		harness.App.Step(10);
+
+		Vector2[] positions = [.. graph.NodePositions];
+		Assert.AreEqual(2, positions.Length, "The schema has two classes, so the graph has two nodes.");
+
+		foreach (Vector2 position in positions)
+		{
+			Assert.IsTrue(
+				position.X > 0f && position.Y > 0f,
+				$"A node was laid out at {position}, off the top-left corner of the canvas.");
+		}
+
+		Vector2 centre = canvas * 0.5f;
+		Vector2 centroid = (positions[0] + positions[1]) * 0.5f;
+		Assert.IsTrue(
+			Vector2.Distance(centroid, centre) < centre.Y,
+			$"The graph settled around {centroid}, which is not the canvas's middle at {centre}.");
 	}
 
 	[TestMethod]

--- a/SchemaEditor.Test/DiagnosticsTests.cs
+++ b/SchemaEditor.Test/DiagnosticsTests.cs
@@ -8,6 +8,8 @@ using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
 using ktsu.Semantics.Strings;
 
+using SchemaTypes = ktsu.Schema.Models.Types;
+
 /// <summary>
 /// The diagnostics panel's logic: when validation runs, and what clicking an issue selects.
 /// </summary>
@@ -47,6 +49,40 @@ public sealed class DiagnosticsTests
 		schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>());
 
 		return schema;
+	}
+
+	/// <summary>
+	/// Validates immediately, rather than waiting out the debounce, and draws the frames that put
+	/// the result on screen.
+	/// </summary>
+	private void Validate()
+	{
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+		harness.App.Step(2);
+	}
+
+	/// <summary>
+	/// The counts are what a schema's health looks like from outside the diagnostics tab, so they
+	/// ride on the tab's own label.
+	/// </summary>
+	[TestMethod]
+	public void TheDiagnosticsTabCarriesTheCounts()
+	{
+		Schema schema = new();
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		user.AddMember("Id".As<MemberName>())!.SetType(new SchemaTypes.Int());
+		harness.Editor.CurrentSchema = schema;
+		Validate();
+
+		Assert.AreEqual("Diagnostics", harness.Editor.DiagnosticsTabLabel, "A clean schema has nothing to count.");
+
+		// An empty class name is an error, and a member left without a type is a warning.
+		schema.AddClass(new ClassName());
+		user.AddMember("Untyped".As<MemberName>());
+		Validate();
+
+		Assert.AreEqual("Diagnostics (1 error, 1 warning)", harness.Editor.DiagnosticsTabLabel);
 	}
 
 	[TestMethod]

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -115,6 +115,22 @@ internal sealed class EditorHarness : IDisposable
 	}
 
 	/// <summary>
+	/// Opens one of the schema tree's tabs, so the rows it holds are drawn.
+	/// </summary>
+	/// <remarks>
+	/// The trees share the left column one tab at a time, so a test that clicks a class, a data
+	/// source or a code generator has to open that tree first. Asked for rather than clicked,
+	/// because at the window sizes these tests run at the tab bar is too narrow for four tabs and
+	/// the rightmost is scrolled out of reach.
+	/// </remarks>
+	/// <param name="name">The tab's name, as the constants on <see cref="TreeSchema"/> give it.</param>
+	internal void SelectTree(string name)
+	{
+		Editor.SelectTree(name);
+		App.Step(3);
+	}
+
+	/// <summary>
 	/// Right-clicks a marked item, which is how the tree opens an item's context menu.
 	/// </summary>
 	/// <param name="item">A marked name, or the trailing part of one.</param>

--- a/SchemaEditor.Test/TreeContextMenuTests.cs
+++ b/SchemaEditor.Test/TreeContextMenuTests.cs
@@ -57,6 +57,8 @@ public sealed class TreeContextMenuTests
 	[TestMethod]
 	public void DeletingAClassRemovesIt()
 	{
+		harness.SelectTree("Classes");
+
 		ChooseFromContextMenu("BtnAccount", "DeleteAccount");
 
 		AssertClasses("User", "Order");
@@ -70,6 +72,8 @@ public sealed class TreeContextMenuTests
 	[TestMethod]
 	public void UndoingAClassDeleteBringsItBackWhereItWas()
 	{
+		harness.SelectTree("Classes");
+
 		ChooseFromContextMenu("BtnAccount", "DeleteAccount");
 
 		harness.Editor.UndoRedo.Undo();
@@ -80,6 +84,8 @@ public sealed class TreeContextMenuTests
 	[TestMethod]
 	public void RenamingAClassChangesItsName()
 	{
+		harness.SelectTree("Classes");
+
 		ChooseFromContextMenu("BtnAccount", "RenameAccount");
 		harness.TypeInto("input/field", "Ledger");
 		harness.Click("input/ok");
@@ -114,6 +120,7 @@ public sealed class TreeContextMenuTests
 		}
 
 		harness.Editor.CurrentSchema = schema;
+		harness.SelectTree("Data Sources");
 	}
 
 	private void AssertDataSources(params string[] expected)
@@ -169,6 +176,7 @@ public sealed class TreeContextMenuTests
 		}
 
 		harness.Editor.CurrentSchema = schema;
+		harness.SelectTree("Code Generators");
 	}
 
 	private void AssertCodeGenerators(params string[] expected)
@@ -227,6 +235,7 @@ public sealed class TreeContextMenuTests
 	{
 		SchemaClass user = schema.GetClass("User".As<ClassName>())!;
 
+		harness.SelectTree("Classes");
 		ChooseFromContextMenu("User/BtnId", "RenameId");
 		harness.TypeInto("input/field", "Identifier");
 		harness.Click("input/ok");
@@ -243,6 +252,8 @@ public sealed class TreeContextMenuTests
 	[TestMethod]
 	public void DeletingAMemberFromTheTreeRemovesIt()
 	{
+		harness.SelectTree("Classes");
+
 		ChooseFromContextMenu("User/BtnAge", "DeleteAge");
 
 		AssertMembersOfUser("Id", "Email");
@@ -255,6 +266,8 @@ public sealed class TreeContextMenuTests
 	[TestMethod]
 	public void UndoingAMemberDeleteFromTheTreeBringsItBackWhereItWas()
 	{
+		harness.SelectTree("Classes");
+
 		ChooseFromContextMenu("User/BtnAge", "DeleteAge");
 		AssertMembersOfUser("Id", "Email");
 

--- a/SchemaEditor.Test/TreeEditingTests.cs
+++ b/SchemaEditor.Test/TreeEditingTests.cs
@@ -42,6 +42,8 @@ public sealed class TreeEditingTests
 	[TestMethod]
 	public void AddingAClassNamesItAndSelectsIt()
 	{
+		harness.SelectTree("Classes");
+
 		AddNamed("NewClass", "Order");
 
 		Assert.IsNotNull(schema.GetClass("Order".As<ClassName>()));
@@ -51,6 +53,8 @@ public sealed class TreeEditingTests
 	[TestMethod]
 	public void AddingAClassIsUndoable()
 	{
+		harness.SelectTree("Classes");
+
 		AddNamed("NewClass", "Order");
 		Assert.IsNotNull(schema.GetClass("Order".As<ClassName>()));
 
@@ -67,6 +71,7 @@ public sealed class TreeEditingTests
 	public void AddingAClassWithANameAlreadyInUseIsRefused()
 	{
 		schema.AddClass("Order".As<ClassName>());
+		harness.SelectTree("Classes");
 
 		AddNamed("NewClass", "Order");
 
@@ -78,6 +83,7 @@ public sealed class TreeEditingTests
 	{
 		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
 		harness.Editor.EditClass(user);
+		harness.SelectTree("Classes");
 
 		AddNamed("User/NewMember", "Age");
 
@@ -105,6 +111,8 @@ public sealed class TreeEditingTests
 	[TestMethod]
 	public void AddingADataSourcePutsItOnTheSchemaAndSelectsIt()
 	{
+		harness.SelectTree("Data Sources");
+
 		AddNamed("NewDataSource", "Users");
 
 		Assert.IsNotNull(schema.GetDataSource("Users".As<DataSourceName>()));
@@ -114,6 +122,8 @@ public sealed class TreeEditingTests
 	[TestMethod]
 	public void AddingACodeGeneratorPutsItOnTheSchema()
 	{
+		harness.SelectTree("Code Generators");
+
 		AddNamed("NewCodeGenerator", "CSharp");
 
 		Assert.IsNotNull(schema.GetCodeGenerator("CSharp".As<CodeGeneratorName>()));

--- a/SchemaEditor.Test/TreeNavigationTests.cs
+++ b/SchemaEditor.Test/TreeNavigationTests.cs
@@ -49,6 +49,7 @@ public sealed class TreeNavigationTests
 	public void ClickingAClassRowSelectsThatClass()
 	{
 		OpenPopulatedSchema();
+		harness.SelectTree("Classes");
 
 		harness.Click("BtnAccount");
 
@@ -63,6 +64,7 @@ public sealed class TreeNavigationTests
 	public void ClickingAMemberRowSelectsItsOwningClass()
 	{
 		OpenPopulatedSchema();
+		harness.SelectTree("Classes");
 		harness.Click("BtnAccount");
 
 		harness.Click("User/BtnAge");
@@ -85,6 +87,7 @@ public sealed class TreeNavigationTests
 	public void ClickingADataSourceRowSelectsThatDataSource()
 	{
 		OpenPopulatedSchema();
+		harness.SelectTree("Data Sources");
 
 		harness.Click("BtnUsers");
 
@@ -95,6 +98,7 @@ public sealed class TreeNavigationTests
 	public void ClickingACodeGeneratorRowSelectsThatCodeGenerator()
 	{
 		OpenPopulatedSchema();
+		harness.SelectTree("Code Generators");
 
 		harness.Click("BtnCSharp");
 
@@ -110,8 +114,11 @@ public sealed class TreeNavigationTests
 	{
 		OpenPopulatedSchema();
 
+		harness.SelectTree("Classes");
 		harness.Click("BtnUser");
+		harness.SelectTree("Data Sources");
 		harness.Click("BtnUsers");
+		harness.SelectTree("Code Generators");
 		harness.Click("BtnCSharp");
 
 		Assert.IsNull(harness.Editor.CurrentClass);

--- a/SchemaEditor.Test/TreeRowWidthTests.cs
+++ b/SchemaEditor.Test/TreeRowWidthTests.cs
@@ -43,8 +43,14 @@ public sealed class TreeRowWidthTests
 		harness = EditorHarness.Start(new HarnessOptions { Width = 700, Height = 600 });
 		harness.Editor.CurrentSchema = new Schema();
 
+		// One tree is drawn at a time, so each heading is measured while its own tab is open.
+		harness.SelectTree("Code Generators");
+		int codeGenerators = WidthOf("RootCode Generators");
+		harness.SelectTree("Enums");
+		int enums = WidthOf("RootEnums");
+
 		Assert.IsTrue(
-			WidthOf("RootCode Generators") > WidthOf("RootEnums"),
+			codeGenerators > enums,
 			"'Code Generators (0)' is the longest heading in the tree; drawn at the same width as 'Enums (0)' it loses its count.");
 	}
 
@@ -56,6 +62,7 @@ public sealed class TreeRowWidthTests
 		schema.AddClass("A".As<ClassName>());
 		schema.AddClass("AClassNameLongEnoughToNeedMoreRoomThanTheColumnGives".As<ClassName>());
 		harness.Editor.CurrentSchema = schema;
+		harness.SelectTree("Classes");
 
 		Assert.IsTrue(
 			WidthOf("BtnAClassNameLongEnoughToNeedMoreRoomThanTheColumnGives") > WidthOf("BtnA"),
@@ -74,6 +81,7 @@ public sealed class TreeRowWidthTests
 		schema.AddClass("A".As<ClassName>());
 		schema.AddClass("Bee".As<ClassName>());
 		harness.Editor.CurrentSchema = schema;
+		harness.SelectTree("Classes");
 
 		Assert.AreEqual(WidthOf("BtnA"), WidthOf("BtnBee"));
 	}

--- a/SchemaEditor.Test/ValidationMarkingTests.cs
+++ b/SchemaEditor.Test/ValidationMarkingTests.cs
@@ -91,26 +91,4 @@ public sealed class ValidationMarkingTests
 		Assert.IsNotNull(harness.Editor.GetIssueFor(id), "The broken reference should have been reported against the member.");
 		Assert.IsTrue(RedPixels() > before, "The member carrying an error was drawn no differently from one without.");
 	}
-
-	/// <summary>
-	/// The menu bar carries the counts as well, so a schema's health is visible without opening the
-	/// diagnostics tab.
-	/// </summary>
-	[TestMethod]
-	public void TheMenuBarIsDrawnInTheErrorColourWhileThereAreErrors()
-	{
-		Schema schema = new();
-		schema.AddClass("User".As<ClassName>());
-		harness.Editor.CurrentSchema = schema;
-		Revalidate();
-		int before = RedPixels();
-
-		// An empty class name is an error, and nothing is selected, so the only thing that can
-		// draw in the error colour is the summary in the menu bar.
-		schema.AddClass(new ClassName());
-		Revalidate();
-
-		Assert.IsTrue(harness.Editor.Diagnostics.Count > 0);
-		Assert.IsTrue(RedPixels() > before, "The menu bar did not report the errors in the error colour.");
-	}
 }

--- a/SchemaEditor/ClassGraphView.cs
+++ b/SchemaEditor/ClassGraphView.cs
@@ -4,6 +4,7 @@ namespace ktsu.SchemaEditor;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using System.Text;
 
@@ -56,11 +57,17 @@ internal sealed class ClassGraphView
 			return;
 		}
 
+		Vector2 editorSize = ImGui.GetContentRegionAvail();
+
 		string signature = ComputeSignature(schema);
 		if (signature != lastSignature)
 		{
-			Rebuild(schema);
+			Rebuild(schema, editorSize * 0.5f);
 			lastSignature = signature;
+
+			// The layout pulls nodes towards this point, so it is the centre of the ring the
+			// rebuild just laid out. Left where it starts, at the origin, gravity would drag the
+			// whole graph into the canvas's top-left corner and hold it there.
 			engine.InitializeWorldOriginToCentroid();
 		}
 
@@ -68,7 +75,6 @@ internal sealed class ClassGraphView
 		engine.SetDraggedNodes(renderer.CurrentlyDraggedNodes);
 		engine.UpdatePhysics(deltaTime);
 
-		Vector2 editorSize = ImGui.GetContentRegionAvail();
 		renderer.Render(engine, editorSize);
 
 		// Node transforms must be read back after rendering, while the editor context is active.
@@ -87,7 +93,9 @@ internal sealed class ClassGraphView
 	/// Rebuilds the node graph from the schema. Classes and enums become nodes; member references
 	/// between them become links.
 	/// </summary>
-	private void Rebuild(Schema schema)
+	/// <param name="schema">The schema to build the graph from.</param>
+	/// <param name="centre">Where on the canvas to lay the nodes out around.</param>
+	private void Rebuild(Schema schema, Vector2 centre)
 	{
 		engine.Clear();
 
@@ -163,15 +171,18 @@ internal sealed class ClassGraphView
 			}
 		}
 
-		// 4. Create the nodes, seeded around a circle so the layout has room to spread out.
+		// 4. Create the nodes, seeded around a circle so the layout has room to spread out. The
+		//    circle is centred on the canvas: ImNodes measures a node's position from the canvas's
+		//    top-left corner, so a ring around the origin is a ring around that corner, with three
+		//    quarters of it off the canvas entirely.
 		Dictionary<string, Node> nodesByKey = [];
 		int count = descriptors.Count;
-		float radius = MathF.Max(250.0f, count * 45.0f);
+		float radius = SeedRadius(count, centre);
 		for (int i = 0; i < count; i++)
 		{
 			NodeDescriptor descriptor = descriptors[i];
 			float angle = i / (float)count * MathF.Tau;
-			Vector2 position = new(MathF.Cos(angle) * radius, MathF.Sin(angle) * radius);
+			Vector2 position = centre + new Vector2(MathF.Cos(angle) * radius, MathF.Sin(angle) * radius);
 			Node node = engine.CreateNode(position, descriptor.Title, inputLabels[descriptor.Key], outputLabels[descriptor.Key]);
 			nodesByKey[descriptor.Key] = node;
 		}
@@ -191,6 +202,34 @@ internal sealed class ClassGraphView
 				targetNode.InputPins[edge.InputPinIndex].Id);
 		}
 	}
+
+	/// <summary>
+	/// The radius of the ring the nodes are seeded on.
+	/// </summary>
+	/// <remarks>
+	/// Wide enough that the nodes do not start on top of each other, and no wider than the canvas,
+	/// so that a graph opens in view rather than needing to be panned to. The layout spreads the
+	/// nodes out from there, which is what makes room for a graph too big for the ring.
+	/// </remarks>
+	/// <param name="count">How many nodes are being laid out.</param>
+	/// <param name="centre">The middle of the canvas, which is half its size.</param>
+	/// <returns>The radius to seed at.</returns>
+	private static float SeedRadius(int count, Vector2 centre)
+	{
+		float wanted = MathF.Max(250.0f, count * 45.0f);
+		float roomOnCanvas = MathF.Min(centre.X, centre.Y) * 0.7f;
+		return roomOnCanvas > 0.0f ? MathF.Min(wanted, roomOnCanvas) : wanted;
+	}
+
+	/// <summary>
+	/// Gets where the nodes sit, measured from the canvas's top-left corner.
+	/// </summary>
+	internal IEnumerable<Vector2> NodePositions => engine.Nodes.Select(node => node.Position);
+
+	/// <summary>
+	/// Gets how big the nodes are, as the node editor last measured them.
+	/// </summary>
+	internal IEnumerable<Vector2> NodeSizes => engine.Nodes.Select(node => node.Dimensions);
 
 	/// <summary>
 	/// Determines whether a member type references another class or enum, and resolves the node key.

--- a/SchemaEditor/DiagnosticsTab.cs
+++ b/SchemaEditor/DiagnosticsTab.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using System.Collections.Generic;
+
+using ktsu.ImGui.Widgets;
+
+/// <summary>
+/// The diagnostics tab's label, which carries the schema's issue counts.
+/// </summary>
+/// <remarks>
+/// The counts used to be drawn at the end of the application menu bar, where ImGuiApp's own menus
+/// follow the editor's and left them reading as a menu nobody could open. The tab is where the
+/// issues themselves are, so the count is one click from the list it counts.
+///
+/// Separate from <see cref="SchemaEditor"/> because reaching a tab by id to rewrite its label
+/// brings the widget library's tab types with it, and that class is already at the coupling the
+/// analyzer allows.
+/// </remarks>
+internal static class DiagnosticsTab
+{
+	/// <summary>
+	/// The tab's name, which is the whole label while the schema is clean.
+	/// </summary>
+	internal const string Name = "Diagnostics";
+
+	/// <summary>
+	/// Puts the counts on the tab, or takes them off once there is nothing to report.
+	/// </summary>
+	/// <param name="tabs">The tab bar the diagnostics tab belongs to.</param>
+	/// <param name="tabId">The tab, as the panel recorded it when adding it.</param>
+	/// <param name="errors">How many errors the schema has.</param>
+	/// <param name="warnings">How many warnings it has.</param>
+	internal static void ShowCounts(ImGuiWidgets.TabPanel tabs, string tabId, int errors, int warnings)
+	{
+		if (tabs.GetTabById(tabId) is ImGuiWidgets.Tab tab)
+		{
+			tab.Label = errors + warnings == 0 ? Name : $"{Name} ({FormatSummary(errors, warnings)})";
+		}
+	}
+
+	/// <summary>
+	/// Gets the label the tab is carrying.
+	/// </summary>
+	/// <param name="tabs">The tab bar the diagnostics tab belongs to.</param>
+	/// <param name="tabId">The tab, as the panel recorded it when adding it.</param>
+	/// <returns>The label, or empty when the tab is not there.</returns>
+	internal static string LabelOf(ImGuiWidgets.TabPanel tabs, string tabId) =>
+		tabs.GetTabById(tabId)?.Label ?? string.Empty;
+
+	/// <summary>
+	/// Counts the issues, leaving out whichever kind there are none of.
+	/// </summary>
+	/// <remarks>
+	/// A schema with two errors and no warnings reads as "2 errors" rather than "2 errors, 0
+	/// warnings": the zero is noise in a tab label, and it was never news in the panel either.
+	/// </remarks>
+	/// <param name="errors">How many errors the schema has.</param>
+	/// <param name="warnings">How many warnings it has.</param>
+	/// <returns>The counts, as text.</returns>
+	internal static string FormatSummary(int errors, int warnings)
+	{
+		List<string> parts = [];
+
+		if (errors > 0)
+		{
+			parts.Add($"{errors} error{(errors == 1 ? string.Empty : "s")}");
+		}
+
+		if (warnings > 0)
+		{
+			parts.Add($"{warnings} warning{(warnings == 1 ? string.Empty : "s")}");
+		}
+
+		return string.Join(", ", parts);
+	}
+}

--- a/SchemaEditor/EditorTheme.cs
+++ b/SchemaEditor/EditorTheme.cs
@@ -66,6 +66,19 @@ internal static class EditorTheme
 		severity == SchemaValidationSeverity.Error ? Error() : Warning();
 
 	/// <summary>
+	/// Scopes the text colour that marks a validation issue, for a message drawn as plain text.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="Severity"/> colours a widget's frame and picks whichever text colour reads on
+	/// top of it, so plain text inside that scope comes out black or white rather than red. Text
+	/// with no frame under it, such as the menu bar summary, takes the severity colour itself.
+	/// </remarks>
+	/// <param name="severity">The severity to colour for.</param>
+	/// <returns>A scope that reverts the colour when disposed.</returns>
+	internal static ScopedTextColor SeverityText(SchemaValidationSeverity severity) =>
+		new(severity == SchemaValidationSeverity.Error ? Palette.Semantic.Error : Palette.Semantic.Warning);
+
+	/// <summary>
 	/// Scopes the colour for something that is wrong.
 	/// </summary>
 	internal static ScopedThemeColor Error() => Theme.FromColor(Palette.Semantic.Error);

--- a/SchemaEditor/Popups.cs
+++ b/SchemaEditor/Popups.cs
@@ -44,8 +44,28 @@ internal sealed class Popups
 	internal void OpenBrowserDirectory(string title, Action<AbsoluteDirectoryPath> onConfirm) =>
 		Queue.Enqueue(() => PopupFilesystemBrowser.ChooseDirectory(title, onConfirm));
 
-	internal void OpenTypeList(string title, string label, IEnumerable<BaseType> items, BaseType? defaultItem, Action<BaseType> onConfirm) =>
-		Queue.Enqueue(() => PopupTypeList.Open(title, label, items, defaultItem, (t) => t.DisplayName, onConfirm));
+	/// <summary>
+	/// Opens the type picker, with the type the caller already holds selected.
+	/// </summary>
+	/// <remarks>
+	/// The types are materialised, and the current one resolved to the instance in that list,
+	/// because the picker redraws from the same sequence every frame and tracks its selection by
+	/// reference. <c>Schema.GetAvailableTypes</c> is lazy and builds fresh instances on each
+	/// enumeration, so passing it straight through gives the picker a different object every frame
+	/// and nothing ever draws as selected.
+	/// </remarks>
+	/// <param name="title">The popup title.</param>
+	/// <param name="label">The label above the list.</param>
+	/// <param name="items">The types that can be chosen from.</param>
+	/// <param name="current">The type held now, or null when there is none.</param>
+	/// <param name="onConfirm">Applies the chosen type.</param>
+	internal void OpenTypeList(string title, string label, IEnumerable<BaseType> items, BaseType? current, Action<BaseType> onConfirm) =>
+		Queue.Enqueue(() =>
+		{
+			List<BaseType> types = [.. items];
+			BaseType? selected = types.Find(type => type == current);
+			PopupTypeList.Open(title, label, types, selected, (t) => t.DisplayName, onConfirm);
+		});
 
 	internal void Update()
 	{

--- a/SchemaEditor/SchemaEditor.Diagnostics.cs
+++ b/SchemaEditor/SchemaEditor.Diagnostics.cs
@@ -66,32 +66,9 @@ public partial class SchemaEditor
 	}
 
 	/// <summary>
-	/// Draws the error and warning counts, so the schema's health is visible without opening the
-	/// diagnostics tab.
+	/// Gets the diagnostics tab's label, which carries the issue counts.
 	/// </summary>
-	private void ShowValidationSummary()
-	{
-		if (Diagnostics.Count == 0)
-		{
-			return;
-		}
-
-		int errors = ErrorCount;
-		int warnings = WarningCount;
-
-		ImGui.Separator();
-		using (EditorTheme.Severity(errors > 0 ? SchemaValidationSeverity.Error : SchemaValidationSeverity.Warning))
-		{
-			ImGui.TextUnformatted(FormatSummary(errors, warnings));
-		}
-	}
-
-	private static string FormatSummary(int errors, int warnings)
-	{
-		string errorText = $"{errors} error{(errors == 1 ? string.Empty : "s")}";
-		string warningText = $"{warnings} warning{(warnings == 1 ? string.Empty : "s")}";
-		return $"{errorText}, {warningText}";
-	}
+	internal string DiagnosticsTabLabel => DiagnosticsTab.LabelOf(MainTabs, diagnosticsTabId);
 
 	private void ShowDiagnosticsPanel()
 	{
@@ -107,7 +84,11 @@ public partial class SchemaEditor
 			return;
 		}
 
-		ImGui.TextUnformatted(FormatSummary(ErrorCount, WarningCount));
+		using (EditorTheme.SeverityText(ErrorCount > 0 ? SchemaValidationSeverity.Error : SchemaValidationSeverity.Warning))
+		{
+			ImGui.TextUnformatted(DiagnosticsTab.FormatSummary(ErrorCount, WarningCount));
+		}
+
 		ImGui.Separator();
 
 		// Errors first: they are what stops the schema being usable.

--- a/SchemaEditor/SchemaEditor.Files.cs
+++ b/SchemaEditor/SchemaEditor.Files.cs
@@ -37,28 +37,6 @@ public partial class SchemaEditor
 			? "Untitled schema"
 			: Path.GetFileName(CurrentSchemaPath);
 
-	/// <summary>
-	/// Draws the open document's name and unsaved marker, plus the validation summary, at the end
-	/// of the application menu bar.
-	/// </summary>
-	/// <remarks>
-	/// The window title carries the same information (see <see cref="UpdateWindowTitle"/>). This is
-	/// kept as well as, not instead of: a maximised window's title bar is easy to overlook, and on a
-	/// tiling window manager it may not be drawn at all.
-	/// </remarks>
-	private void ShowDocumentStatus()
-	{
-		if (CurrentSchema is null)
-		{
-			return;
-		}
-
-		ImGui.Separator();
-		ImGui.TextUnformatted($"{DocumentName}{(HasUnsavedChanges ? "*" : string.Empty)}");
-
-		ShowValidationSummary();
-	}
-
 	private void ShowRecentFilesMenu()
 	{
 		IReadOnlyList<AbsoluteFilePath> recent = [.. Options.RecentFiles];

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -42,6 +42,9 @@ public partial class SchemaEditor
 	private ClassGraphView ClassGraph { get; } = new();
 	private ImGuiWidgets.TabPanel MainTabs { get; }
 
+	// The tab whose label carries the validation counts.
+	private readonly string diagnosticsTabId;
+
 	// Tab content delegates are parameterless, so the current frame's delta is stashed here for them.
 	private float currentDeltaTime;
 
@@ -66,7 +69,7 @@ public partial class SchemaEditor
 		MainTabs = new ImGuiWidgets.TabPanel("MainViews", closable: false, reorderable: false);
 		MainTabs.AddTab("Editor", ShowEditorPanel);
 		MainTabs.AddTab("Class Graph", () => ClassGraph.Show(CurrentSchema, currentDeltaTime));
-		MainTabs.AddTab("Diagnostics", ShowDiagnosticsPanel);
+		diagnosticsTabId = MainTabs.AddTab(DiagnosticsTab.Name, ShowDiagnosticsPanel);
 
 		Options = AppData.LoadOrCreate();
 		Popups = Options.Popups;
@@ -243,7 +246,11 @@ public partial class SchemaEditor
 	private void ShowLeftPanel(float dt) => TreeSchema.Show();
 
 	// The right zone hosts the Editor / Class Graph / Diagnostics tab bar.
-	private void ShowRightPanel(float dt) => MainTabs.Draw();
+	private void ShowRightPanel(float dt)
+	{
+		DiagnosticsTab.ShowCounts(MainTabs, diagnosticsTabId, ErrorCount, WarningCount);
+		MainTabs.Draw();
+	}
 
 	private void ShowEditorPanel()
 	{
@@ -276,8 +283,6 @@ public partial class SchemaEditor
 		{
 			RecordThemeChoice();
 		}
-
-		ShowDocumentStatus();
 	}
 
 	private void ShowFileMenu()
@@ -424,6 +429,7 @@ public partial class SchemaEditor
 	{
 		ClearSelection();
 		CurrentClass = schemaClass;
+		SelectTree(TreeSchema.ClassesTab);
 		QueueSaveOptions();
 	}
 
@@ -433,6 +439,7 @@ public partial class SchemaEditor
 	{
 		ClearSelection();
 		CurrentDataSource = dataSource;
+		SelectTree(TreeSchema.DataSourcesTab);
 		QueueSaveOptions();
 	}
 
@@ -440,6 +447,7 @@ public partial class SchemaEditor
 	{
 		ClearSelection();
 		CurrentEnum = schemaEnum;
+		SelectTree(TreeSchema.EnumsTab);
 		QueueSaveOptions();
 	}
 
@@ -449,8 +457,15 @@ public partial class SchemaEditor
 	{
 		ClearSelection();
 		CurrentCodeGenerator = codeGenerator;
+		SelectTree(TreeSchema.CodeGeneratorsTab);
 		QueueSaveOptions();
 	}
+
+	/// <summary>
+	/// Opens the tree tab holding one kind of element.
+	/// </summary>
+	/// <param name="name">The tab's name, as the constants on <see cref="TreeSchema"/> give it.</param>
+	internal void SelectTree(string name) => TreeSchema.SelectTab(name);
 
 	private void ClearSelection()
 	{

--- a/SchemaEditor/TreeClass.cs
+++ b/SchemaEditor/TreeClass.cs
@@ -33,7 +33,7 @@ internal sealed class TreeClass(SchemaEditor schemaEditor)
 				GetTooltip = (x) => x.Description,
 				GetIssue = schemaEditor.GetIssueFor,
 				GetId = (x) => x.Name,
-				OnTreeEnd = (t) =>
+				OnTreeStart = (t) =>
 				{
 					using (t.Child)
 					{
@@ -90,7 +90,7 @@ internal sealed class TreeClass(SchemaEditor schemaEditor)
 			GetIssue = schemaEditor.GetIssueFor,
 			GetId = (x) => x.Name,
 			OnItemClick = (x) => schemaEditor.EditClass(schemaClass),
-			OnTreeEnd = (t) =>
+			OnTreeStart = (t) =>
 			{
 				using (t.Child)
 				{

--- a/SchemaEditor/TreeCodeGenerator.cs
+++ b/SchemaEditor/TreeCodeGenerator.cs
@@ -31,7 +31,7 @@ internal sealed class TreeCodeGenerator(SchemaEditor schemaEditor)
 				GetIssue = schemaEditor.GetIssueFor,
 				GetId = (x) => x.Name,
 				OnItemClick = schemaEditor.EditCodeGenerator,
-				OnTreeEnd = (t) =>
+				OnTreeStart = (t) =>
 				{
 					using (t.Child)
 					{

--- a/SchemaEditor/TreeDataSource.cs
+++ b/SchemaEditor/TreeDataSource.cs
@@ -30,7 +30,7 @@ internal sealed class TreeDataSource(SchemaEditor schemaEditor)
 				GetTooltip = (x) => x.Description,
 				GetIssue = schemaEditor.GetIssueFor,
 				GetId = (x) => x.Name,
-				OnTreeEnd = (t) =>
+				OnTreeStart = (t) =>
 				{
 					using (t.Child)
 					{

--- a/SchemaEditor/TreeEnum.cs
+++ b/SchemaEditor/TreeEnum.cs
@@ -32,7 +32,7 @@ internal sealed class TreeEnum(SchemaEditor schemaEditor)
 				GetIssue = schemaEditor.GetIssueFor,
 				GetId = (x) => x.Name,
 				OnItemClick = schemaEditor.EditEnum,
-				OnTreeEnd = (t) =>
+				OnTreeStart = (t) =>
 				{
 					using (t.Child)
 					{
@@ -99,7 +99,7 @@ internal sealed class TreeEnum(SchemaEditor schemaEditor)
 						ChangeType.Delete));
 				}
 			},
-			OnTreeEnd = (t) =>
+			OnTreeStart = (t) =>
 			{
 				using (t.Child)
 				{

--- a/SchemaEditor/TreeSchema.cs
+++ b/SchemaEditor/TreeSchema.cs
@@ -2,18 +2,79 @@
 
 namespace ktsu.SchemaEditor;
 
+using System;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Probes;
+
+/// <summary>
+/// The schema tree panel: one tab per kind of schema element.
+/// </summary>
+/// <remarks>
+/// Tabbed rather than stacked because the four trees share one narrow column, and a schema with a
+/// dozen classes pushed the data sources and code generators off the bottom of it. Each tree keeps
+/// its own heading, which is where its count is shown.
+/// </remarks>
 internal sealed class TreeSchema(SchemaEditor schemaEditor)
 {
+	internal const string EnumsTab = "Enums";
+	internal const string ClassesTab = "Classes";
+	internal const string DataSourcesTab = "Data Sources";
+	internal const string CodeGeneratorsTab = "Code Generators";
+
 	private TreeEnum TreeEnum { get; } = new(schemaEditor);
 	private TreeClass TreeClass { get; } = new(schemaEditor);
 	private TreeDataSource TreeDataSource { get; } = new(schemaEditor);
 	private TreeCodeGenerator TreeCodeGenerator { get; } = new(schemaEditor);
 
+	/// <summary>
+	/// The tab to open on the next frame, or null when the open tab is whatever was clicked last.
+	/// </summary>
+	private string? tabToOpen;
+
+	/// <summary>
+	/// Opens the tab holding one kind of element, on the next frame drawn.
+	/// </summary>
+	/// <remarks>
+	/// Selecting an element does this, so that navigating to a diagnostic - or to anything else
+	/// the editor selects on the user's behalf - brings up the tree the element is in rather than
+	/// leaving its row behind a tab the user has to find.
+	/// </remarks>
+	/// <param name="name">The tab's name, as the constants on this class give it.</param>
+	internal void SelectTab(string name) => tabToOpen = name;
+
 	internal void Show()
 	{
-		TreeEnum.Show();
-		TreeClass.Show();
-		TreeDataSource.Show();
-		TreeCodeGenerator.Show();
+		if (!ImGui.BeginTabBar("SchemaTrees"))
+		{
+			return;
+		}
+
+		ShowTab(EnumsTab, TreeEnum.Show);
+		ShowTab(ClassesTab, TreeClass.Show);
+		ShowTab(DataSourcesTab, TreeDataSource.Show);
+		ShowTab(CodeGeneratorsTab, TreeCodeGenerator.Show);
+
+		ImGui.EndTabBar();
+		tabToOpen = null;
+	}
+
+	/// <summary>
+	/// Draws one tree behind its tab.
+	/// </summary>
+	/// <param name="name">The kind of element the tree holds.</param>
+	/// <param name="show">Draws the tree.</param>
+	private void ShowTab(string name, Action show)
+	{
+		ImGuiTabItemFlags flags = name == tabToOpen ? ImGuiTabItemFlags.SetSelected : ImGuiTabItemFlags.None;
+		bool selected = ImGui.BeginTabItem(name, flags);
+		ImGuiProbes.MarkItem("tree-tab", name);
+
+		if (selected)
+		{
+			show();
+			ImGui.EndTabItem();
+		}
 	}
 }


### PR DESCRIPTION
The editor's menu bar, left panel and class graph all get their layout reworked, and the package fixes they were waiting on land with them.

## What changes for the user

The menu bar is File, Edit and Theme again. The open document's name lives in the window title alone, and the validation counts ride on the Diagnostics tab's label, one click from the list they count.

The four schema trees each get a tab instead of sharing one narrow column, so a schema with a dozen classes no longer pushes its data sources and code generators off the bottom. Selecting an element opens the tab it lives in, and every "+ New" button sits at the top of its tree.

The class graph opens around the middle of its canvas instead of in the top-left corner, and no longer draws an ImGui warning over the application or grows an unreferenced enum's node wider every frame. The type picker shows what you have selected and confirms on a single click.

## How

`ShowDocumentStatus` is gone, and `DiagnosticsTab` keeps the counts on the tab label. That work turned up a defect worth naming: the summary had never actually been coloured, because `EditorTheme.Severity` scopes a widget's frame and picks whichever text colour reads on top of it, so plain text inside that scope came out black or white. The new `EditorTheme.SeverityText` colours plain text, and the diagnostics panel headline uses it too.

`TreeSchema` draws a tab per kind and can be asked to open one, which `SchemaEditor.SelectTree` exposes and the `Edit*` methods call. The "+ New" buttons moved from `OnTreeEnd` to `OnTreeStart` in all six trees, nested member and enum value trees included.

`ClassGraphView` seeds its ring on the canvas centre, clamped to fit, so the layout's gravity settles the graph in view. `Popups.OpenTypeList` materialises the available types and resolves the current one to the instance in that list, because the picker redraws from the same sequence every frame and `Schema.GetAvailableTypes` builds fresh objects on each enumeration.

The package bump moves all eight packages that ship from ImGuiApp together, since they release as one version, and ThemeProvider to 3.0.15 with them because ImGui.Styler 3.16.8 requires it.

## Tests

100 pass, none skipped. The tree tests open the tab they need through a new harness helper. New tests cover what changed: the Diagnostics tab carries the counts, the graph opens around the middle of the canvas, and a node with no pins draws without an ImGui error and keeps its size. The last of those was written against 3.16.6, where it failed, and is what confirms the package fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWrfVmf1yQ7vE4ZFab7qV7
