### PR TITLE
Move to the renamed ktsu.ImGui.NodeEditor package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
     <PackageVersion Include="ktsu.CodeBlocker" Version="2.0.4" />
     <PackageVersion Include="ktsu.DeepClone" Version="2.0.30" />
     <PackageVersion Include="ktsu.Extensions" Version="1.6.9" />
-    <PackageVersion Include="ktsu.ForceDirectedLayout" Version="3.16.11" />
+    <PackageVersion Include="ktsu.ForceDirectedLayout" Version="3.19.0" />
     <PackageVersion Include="ktsu.FuzzySearch" Version="1.2.39" />
-    <PackageVersion Include="ktsu.ImGui.Styler" Version="3.16.11" />
+    <PackageVersion Include="ktsu.ImGui.Styler" Version="3.19.0" />
     <PackageVersion Include="ktsu.ThemeProvider" Version="3.0.17" />
     <PackageVersion Include="ktsu.IntervalAction" Version="1.3.41" />
     <PackageVersion Include="ktsu.Keybinding.Core" Version="1.0.43" />
@@ -18,12 +18,12 @@
     <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.54" />
     <PackageVersion Include="ktsu.Semantics.Strings" Version="3.2.7" />
     <PackageVersion Include="ktsu.Semantics.Paths" Version="3.2.7" />
-    <PackageVersion Include="ktsu.ImGui.App" Version="3.16.11" />
-    <PackageVersion Include="ktsu.ImGui.App.Testing" Version="3.16.11" />
-    <PackageVersion Include="ktsu.ImGui.Popups" Version="3.16.11" />
-    <PackageVersion Include="ktsu.ImGui.Probes" Version="3.16.11" />
-    <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.16.11" />
-    <PackageVersion Include="ktsu.ImGuiNodeEditor" Version="3.16.11" />
+    <PackageVersion Include="ktsu.ImGui.App" Version="3.19.0" />
+    <PackageVersion Include="ktsu.ImGui.App.Testing" Version="3.19.0" />
+    <PackageVersion Include="ktsu.ImGui.Popups" Version="3.19.0" />
+    <PackageVersion Include="ktsu.ImGui.Probes" Version="3.19.0" />
+    <PackageVersion Include="ktsu.ImGui.Widgets" Version="3.19.0" />
+    <PackageVersion Include="ktsu.ImGui.NodeEditor" Version="3.19.0" />
     <PackageVersion Include="ktsu.NodeGraph" Version="1.0.0" />
     <PackageVersion Include="ktsu.AppDataStorage" Version="1.16.52" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />

--- a/SchemaEditor.Test/ClassGraphTests.cs
+++ b/SchemaEditor.Test/ClassGraphTests.cs
@@ -64,7 +64,7 @@ public sealed class ClassGraphTests
 	/// every frame the graph was open, and the node's measured width grew by eight pixels a frame,
 	/// without limit, for as long as it was on screen.
 	///
-	/// The node is drawn by ktsu.ImGuiNodeEditor, so that is where the fix is: it submits an item
+	/// The node is drawn by ktsu.ImGui.NodeEditor, so that is where the fix is: it submits an item
 	/// of its own for a node with no pins, from 3.16.8.
 	/// </remarks>
 	[TestMethod]

--- a/SchemaEditor/ClassGraphView.cs
+++ b/SchemaEditor/ClassGraphView.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 using Hexa.NET.ImGui;
 
-using ktsu.ImGuiNodeEditor;
+using ktsu.ImGui.NodeEditor;
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
 
@@ -18,7 +18,7 @@ using SchemaTypes = Schema.Models.Types;
 
 /// <summary>
 /// Renders the relationships between schema classes and enums as an interactive node graph
-/// using <c>ktsu.NodeGraph</c> metadata concepts and the <c>ktsu.ImGuiNodeEditor</c> engine.
+/// using <c>ktsu.NodeGraph</c> metadata concepts and the <c>ktsu.ImGui.NodeEditor</c> engine.
 ///
 /// Each class and enum becomes a node. A member whose type references another class or enum
 /// (directly, or as the element type of an array) becomes a link from the owning class to the

--- a/SchemaEditor/SchemaEditor.csproj
+++ b/SchemaEditor/SchemaEditor.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="ktsu.ImGui.Probes" />
     <PackageReference Include="ktsu.ImGui.Styler" />
     <PackageReference Include="ktsu.ImGui.Widgets" />
-    <PackageReference Include="ktsu.ImGuiNodeEditor" />
+    <PackageReference Include="ktsu.ImGui.NodeEditor" />
     <PackageReference Include="ktsu.NodeGraph" />
     <PackageReference Include="ktsu.IntervalAction" />
     <PackageReference Include="ktsu.Keybinding.Core" />


### PR DESCRIPTION
ImGuiApp renamed `ktsu.ImGuiNodeEditor` to `ktsu.ImGui.NodeEditor` in 3.19.0 ([ktsu-dev/ImGuiApp#356](https://github.com/ktsu-dev/ImGuiApp/pull/356)), bringing the node editor in line with every other ImGui-facing package in that suite. The old id stops at 3.18.0, so staying on it means never taking another node editor release.

## The rename

The package id, the namespace, and the prose that names either:

| File | What changed |
| --- | --- |
| `Directory.Packages.props`, `SchemaEditor/SchemaEditor.csproj` | The package id |
| `SchemaEditor/ClassGraphView.cs` | `using ktsu.ImGui.NodeEditor;`, and the class summary that names the engine |
| `SchemaEditor.Test/ClassGraphTests.cs` | A remark explaining where a node-width bug was fixed |

No API changed in the move, so the graph code itself is untouched. `CHANGELOG.md` keeps the old name — it records what was released at the time, not a reference that has to resolve.

## The version bump that comes with it

`ktsu.ImGui.NodeEditor` only exists from 3.19.0, and pinning it there forces the rest of the suite up with it from 3.16.11 — a mixed set trips NU1605. `ktsu.ForceDirectedLayout` proved that first: the node editor depends on it directly, so leaving it at 3.16.11 failed restore with a downgrade error before anything compiled. `ktsu.ImGui.App`, `ktsu.ImGui.App.Testing`, `ktsu.ImGui.Popups`, `ktsu.ImGui.Probes`, `ktsu.ImGui.Widgets`, `ktsu.ImGui.Styler` and `ktsu.ForceDirectedLayout` all move 3.16.11 → 3.19.0. `ktsu.NodeGraph` versions independently and stays at 1.0.0.

## Verification

`dotnet build -c Release` is clean and the `net10.0` test heads pass — 404 tests, 0 failed, `SchemaEditor.Test` included, so the class graph view is exercised against the renamed package.

The `net8.0` and `net9.0` heads of `Schema.Test` could not launch in the environment I built in, which has only the .NET 10 runtime installed. Nothing in this change touches those targets, and CI runs them normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qVmjxGLzVE2mZctNNjSJC

---
_Generated by [Claude Code](https://claude.ai/code/session_015qVmjxGLzVE2mZctNNjSJC)_