### PR TITLE
Cover the editor's menus, panels and diagnostics list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,24 @@ Schema elements maintain parent references via `AssociateWith()` methods. After 
 - `SchemaEditor/EditorTheme.cs` - The ktsu.ThemeProvider theme, and the one definition of how a validation issue is coloured
 - `SchemaEditor/Program.cs` - The entry point, and the only file excluded from coverage measurement
 - `SchemaEditor.Test/EditorHarness.cs` - Runs a real editor headlessly, frames advanced by the test
-- `SchemaEditor.Test/WidgetHarness.cs` - A headless frame containing only the widget under test
+- `SchemaEditor.Test/WidgetHarness.cs` - A headless frame containing only the widget under test, and an editor for a panel that is one
+
+### Addressing the editor from a test
+
+The editor's own draw code records where it put things, through `ImGuiProbes.MarkItem` from
+`ktsu.ImGui.Probes`. That is what lets a test click a widget by name rather than by pixel position,
+and it costs nothing when no probe is installed - which is every run that is not a test. Marking is
+therefore part of drawing a control, not an afterthought: a new button, menu item or picker option
+that a test will need is marked where it is submitted.
+
+The names are qualified by the ImGui window and any pushed scope, and a test matches on the trailing
+part: `menu/New`, `field/ClassNameUser`, `memberId/Delete`, `diagnostic/Error:Users`. Rows that share
+a label push a probe scope alongside `ImGui.PushID`, so two members' fields do not collide.
+
+One thing has no name to click: the right-hand tab bar comes from a widget library that neither
+records its tabs nor takes a selection from outside. A panel behind it - the class graph, the
+diagnostics list - is tested by drawing it directly in a `WidgetHarness`, which is what the tab's
+own delegate does.
 
 ## Dependencies
 

--- a/SchemaEditor.Test/CodeGeneratorPanelTests.cs
+++ b/SchemaEditor.Test/CodeGeneratorPanelTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+using System.Linq;
+
+using ktsu.Schema.Generation;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+/// <summary>
+/// The code generator panel: configuring one, and running it.
+/// </summary>
+/// <remarks>
+/// Until this panel existed a code generator could be created and deleted but never configured, so
+/// every one in a saved schema tripped the "does not specify an output path" warning. What it is
+/// for is therefore the fields - the language, the namespace, the output path - and the button that
+/// runs the generator with them.
+/// </remarks>
+[TestClass]
+public sealed class CodeGeneratorPanelTests
+{
+	private EditorHarness harness = null!;
+	private Schema schema = null!;
+	private SchemaCodeGenerator generator = null!;
+	private AbsoluteDirectoryPath scratchDirectory = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+
+		// A real directory, not the in-memory one: generation writes through System.IO directly.
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-editor-generator-tests-{Guid.NewGuid():N}".As<DirectoryName>();
+		Directory.CreateDirectory(scratchDirectory);
+
+		schema = new Schema();
+		generator = schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>())!;
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.EditCodeGenerator(generator);
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		harness.Dispose();
+
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	/// <summary>
+	/// Anchors the schema to a file on disk, which is what output paths are resolved against.
+	/// </summary>
+	private void SaveSchemaTo(string name)
+	{
+		AbsoluteFilePath path = scratchDirectory / name.As<FileName>();
+		File.WriteAllText(path, SchemaSerializer.Serialize(schema));
+		schema.SetSourceFile(path);
+		harness.Editor.CurrentSchemaPath = path;
+		harness.App.Step(2);
+	}
+
+	private bool IsShowing(string item) => harness.App.Probe.Matches(item).Count > 0;
+
+	[TestMethod]
+	public void RenamingACodeGeneratorFromItsPanelRenamesIt()
+	{
+		harness.Commit("field/CodeGeneratorNameCSharp", "Pocos");
+
+		Assert.AreEqual("Pocos", generator.Name.ToString());
+	}
+
+	[TestMethod]
+	public void SettingTheNamespaceRecordsIt()
+	{
+		harness.Commit("field/CodeGeneratorNamespaceCSharp", "Contoso.Model");
+
+		Assert.AreEqual("Contoso.Model", generator.Namespace.ToString());
+	}
+
+	[TestMethod]
+	public void SettingTheNamespaceIsUndoable()
+	{
+		harness.Commit("field/CodeGeneratorNamespaceCSharp", "Contoso.Model");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual(string.Empty, generator.Namespace.ToString());
+	}
+
+	[TestMethod]
+	public void SettingTheOutputPathRecordsIt()
+	{
+		harness.Commit("field/CodeGeneratorOutputCSharp", "generated");
+
+		Assert.AreEqual("generated", generator.OutputPath.ToString());
+	}
+
+	[TestMethod]
+	public void BrowsingForAnOutputPathAsksForADirectory()
+	{
+		harness.Click("browse/CSharp");
+		harness.App.Step(4);
+
+		Assert.IsTrue(IsShowing("filesystem-browser/cancel"), "The directory browser was not raised.");
+	}
+
+	[TestMethod]
+	public void ChoosingALanguageSetsIt()
+	{
+		harness.Click("language-selector/CSharp");
+		harness.Click($"language-option/{SchemaGenerator.SupportedLanguages.First()}");
+
+		Assert.AreEqual(SchemaGenerator.SupportedLanguages.First(), generator.Language.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingALanguageIsUndoable()
+	{
+		harness.Click("language-selector/CSharp");
+		harness.Click($"language-option/{SchemaGenerator.SupportedLanguages.First()}");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual(string.Empty, generator.Language.ToString());
+	}
+
+	[TestMethod]
+	public void EditingTheDescriptionRecordsIt()
+	{
+		harness.TypeInto("field/CodeGeneratorDescriptionCSharp", "Plain classes for the model.");
+		harness.Click("field/CodeGeneratorNameCSharp");
+
+		Assert.AreEqual("Plain classes for the model.", generator.Description.ToString());
+	}
+
+	/// <summary>
+	/// Output paths are relative to the schema file, so there is nothing to resolve them against
+	/// until the schema has been saved. The panel says so rather than offering a button that would
+	/// fail.
+	/// </summary>
+	[TestMethod]
+	public void GeneratingIsNotOfferedUntilTheSchemaHasBeenSaved()
+	{
+		harness.App.Step(2);
+
+		Assert.IsFalse(schema.CanResolvePaths, "This test is about a schema that has never been saved.");
+		Assert.IsFalse(IsShowing("generate/CSharp"), "Generating was offered with nothing to resolve output paths against.");
+	}
+
+	[TestMethod]
+	public void GeneratingIsOfferedOnceTheSchemaHasBeenSaved()
+	{
+		SaveSchemaTo("offered.schema.json");
+
+		Assert.IsTrue(IsShowing("generate/CSharp"));
+	}
+
+	[TestMethod]
+	public void GeneratingWritesTheOutputAndSaysSo()
+	{
+		schema.AddClass("User".As<ClassName>())!.AddMember("Id".As<MemberName>())!.SetType(new SchemaTypes.Int());
+		generator.Language = SchemaGenerator.SupportedLanguages.First().As<LanguageName>();
+		generator.Namespace = "Contoso.Model".As<CodeNamespace>();
+		generator.OutputPath = "generated".As<RelativeDirectoryPath>();
+		SaveSchemaTo("generating.schema.json");
+
+		harness.Click("generate/CSharp");
+		harness.App.Step(3);
+
+		Assert.IsTrue(Directory.Exists(scratchDirectory / "generated".As<DirectoryName>()), "Nothing was written.");
+		Assert.IsTrue(IsShowing("prompt/OK"), "Generating said nothing about what it had done.");
+	}
+
+	/// <summary>
+	/// A generator that cannot run says why. A schema with errors in it is the case worth pointing
+	/// at the diagnostics tab, since that is where the errors can be acted on.
+	/// </summary>
+	[TestMethod]
+	public void GeneratingAnInvalidSchemaIsRefusedWithAReason()
+	{
+		// A member pointing at a class that is not there: an error, so generation is refused.
+		schema.AddClass("User".As<ClassName>())!
+			.AddMember("Owner".As<MemberName>())!
+			.SetType(new SchemaTypes.Object() { ClassName = "Missing".As<ClassName>() });
+		generator.Language = SchemaGenerator.SupportedLanguages.First().As<LanguageName>();
+		generator.OutputPath = "generated".As<RelativeDirectoryPath>();
+		SaveSchemaTo("invalid.schema.json");
+
+		harness.Click("generate/CSharp");
+		harness.App.Step(3);
+
+		Assert.IsFalse(Directory.Exists(scratchDirectory / "generated".As<DirectoryName>()), "A schema with errors in it was generated anyway.");
+		Assert.IsTrue(IsShowing("prompt/OK"), "The refusal was not reported.");
+	}
+}

--- a/SchemaEditor.Test/DiagnosticsPanelTests.cs
+++ b/SchemaEditor.Test/DiagnosticsPanelTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System.Linq;
+
+using ktsu.ImGui.App.Testing;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+/// <summary>
+/// The diagnostics panel itself: what it lists, in what order, and what clicking a row does.
+/// </summary>
+/// <remarks>
+/// Driven through <see cref="WidgetHarness"/> rather than through the editor, for the same reason
+/// the class graph is: the panel lives behind a tab, and the tab bar comes from a widget library
+/// that neither records its tabs for a probe nor takes a selection from outside - so there is no
+/// tab for a test to click. Drawing the panel directly is what the tab delegate does anyway.
+/// </remarks>
+[TestClass]
+public sealed class DiagnosticsPanelTests
+{
+	private WidgetHarness harness = null!;
+
+	[TestInitialize]
+	public void StartHarness()
+	{
+		harness = WidgetHarness.Start();
+		harness.Draw = harness.Editor.ShowDiagnosticsPanel;
+	}
+
+	[TestCleanup]
+	public void StopHarness() => harness.Dispose();
+
+	/// <summary>
+	/// A schema with one warning and one error, each naming a different element, so the panel has
+	/// both severities to draw and something to order them by.
+	/// </summary>
+	private static Schema BuildSchemaWithAWarningAndAnError()
+	{
+		Schema schema = new();
+
+		// A member with no type: a warning, reported against the member.
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		user.AddMember("Untyped".As<MemberName>());
+
+		// A data source pointing at a class that is not there: an error, against the data source.
+		DataSource dataSource = schema.AddDataSource("Users".As<DataSourceName>())!;
+		dataSource.ClassName = "Missing".As<ClassName>();
+
+		return schema;
+	}
+
+	/// <summary>
+	/// Validates immediately, rather than waiting out the debounce, and draws the frames that put
+	/// the result on screen.
+	/// </summary>
+	private void Validate()
+	{
+		harness.Editor.RequestValidation();
+		harness.Editor.UpdateValidation(SchemaEditor.ValidationDebounceSeconds);
+		harness.App.Step(3);
+	}
+
+	/// <summary>
+	/// The rows the panel drew, named as the panel records them: severity and path.
+	/// </summary>
+	private string[] ListedIssues =>
+		[.. harness.App.Probe.KnownNames
+			.Where(name => name.Contains("/diagnostic/", StringComparison.Ordinal))
+			.Select(name => name[(name.LastIndexOf('/') + 1)..])];
+
+	[TestMethod]
+	public void NothingIsListedWithNoSchemaOpen()
+	{
+		harness.App.Step(2);
+
+		Assert.IsNull(harness.Editor.CurrentSchema, "This test is about the panel with no document behind it.");
+		Assert.AreEqual(0, ListedIssues.Length);
+	}
+
+	[TestMethod]
+	public void NothingIsListedForASchemaWithNoIssues()
+	{
+		Schema schema = new();
+		schema.AddClass("User".As<ClassName>())!.AddMember("Id".As<MemberName>())!.SetType(new SchemaTypes.Int());
+		harness.Editor.CurrentSchema = schema;
+		Validate();
+
+		Assert.AreEqual(0, harness.Editor.Diagnostics.Count, "This schema was supposed to start clean.");
+		Assert.AreEqual(0, ListedIssues.Length);
+	}
+
+	[TestMethod]
+	public void EveryIssueGetsARow()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAWarningAndAnError();
+		Validate();
+
+		CollectionAssert.AreEquivalent(
+			harness.Editor.Diagnostics.Select(i => $"{i.Severity}:{i.Path}").Distinct().ToArray(),
+			ListedIssues.Distinct().ToArray());
+	}
+
+	/// <summary>
+	/// Errors are what stops a schema being usable, so they are listed above the warnings however
+	/// validation happened to report them.
+	/// </summary>
+	[TestMethod]
+	public void ErrorsAreListedBeforeWarnings()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAWarningAndAnError();
+		Validate();
+
+		Rectangle error = harness.App.Probe.Rect("diagnostic/Error:Users")
+			?? throw new AssertFailedException("The data source's error was not listed.");
+		Rectangle warning = harness.App.Probe.Rect("diagnostic/Warning:User.Untyped")
+			?? throw new AssertFailedException("The member's warning was not listed.");
+
+		Assert.IsTrue(error.MinY < warning.MinY, "The warning was listed above the error.");
+	}
+
+	/// <summary>
+	/// The row is a navigation target rather than a line of text: clicking it selects the element
+	/// the issue is about, which is the whole reason it is a selectable.
+	/// </summary>
+	[TestMethod]
+	public void ClickingARowSelectsTheElementTheIssueIsAbout()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAWarningAndAnError();
+		Validate();
+
+		harness.App.Click("diagnostic/Error:Users");
+		harness.App.Step(2);
+
+		Assert.AreEqual("Users", harness.Editor.CurrentDataSource?.Name.ToString());
+	}
+
+	/// <summary>
+	/// A member has no panel of its own, so its row selects the class its row is drawn in.
+	/// </summary>
+	[TestMethod]
+	public void ClickingAMemberRowSelectsItsOwningClass()
+	{
+		harness.Editor.CurrentSchema = BuildSchemaWithAWarningAndAnError();
+		Validate();
+
+		harness.App.Click("diagnostic/Warning:User.Untyped");
+		harness.App.Step(2);
+
+		Assert.AreEqual("User", harness.Editor.CurrentClass?.Name.ToString());
+	}
+}

--- a/SchemaEditor.Test/DocumentGuardTests.cs
+++ b/SchemaEditor.Test/DocumentGuardTests.cs
@@ -324,6 +324,25 @@ public sealed class DocumentGuardTests
 	}
 
 	/// <summary>
+	/// Backing out of the close prompt has to release the latch that stops a second prompt stacking
+	/// on the first, or the close button would stop working for the rest of the session.
+	/// </summary>
+	[TestMethod]
+	public void BackingOutOfTheClosePromptLeavesTheCloseButtonWorking()
+	{
+		OpenDirtyDocument();
+		Assert.IsFalse(harness.Editor.ShouldClose());
+		AnswerPrompt("Cancel");
+
+		Assert.IsFalse(harness.Editor.ShouldClose());
+		harness.App.Step(4);
+
+		Assert.IsTrue(
+			harness.IsOnScreen("prompt/Discard"),
+			"A second close raised no prompt, so the editor could no longer be closed.");
+	}
+
+	/// <summary>
 	/// Hitting the close button repeatedly must not stack a prompt per press, which would leave the
 	/// user dismissing the same question several times.
 	/// </summary>

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -131,6 +131,40 @@ internal sealed class EditorHarness : IDisposable
 	}
 
 	/// <summary>
+	/// Whether a marked item was drawn in the frame just rendered.
+	/// </summary>
+	/// <remarks>
+	/// Not the same question as whether the probe has ever seen it: the probe remembers every name
+	/// it has recorded, so a popup that has been dismissed still matches by name. This is what to
+	/// ask about something that is expected to have gone away, or to have come back.
+	/// </remarks>
+	/// <param name="item">A marked name, or the trailing part of one.</param>
+	internal bool IsOnScreen(string item) => App.Probe.WasSeenInFrame(item, App.FrameCount - 1);
+
+	/// <summary>
+	/// Opens one of the application menus in the menu bar.
+	/// </summary>
+	/// <remarks>
+	/// Named by its window, unlike the items inside it. A menu header is recorded twice - once as
+	/// the bar draws it, and again inside the popup it opens, since that popup is the window the
+	/// mark is qualified by - so the bare name stops identifying one item as soon as the menu has
+	/// been opened once.
+	/// </remarks>
+	/// <param name="name">The menu's label, as the menu bar draws it.</param>
+	internal void OpenMenu(string name) => Click($"##MainMenuBar/menu/{name}");
+
+	/// <summary>
+	/// Opens a menu and chooses one of its items.
+	/// </summary>
+	/// <param name="menu">The menu's label.</param>
+	/// <param name="item">The item's label.</param>
+	internal void ChooseMenuItem(string menu, string item)
+	{
+		OpenMenu(menu);
+		Click($"menu/{item}");
+	}
+
+	/// <summary>
 	/// Right-clicks a marked item, which is how the tree opens an item's context menu.
 	/// </summary>
 	/// <param name="item">A marked name, or the trailing part of one.</param>
@@ -154,6 +188,24 @@ internal sealed class EditorHarness : IDisposable
 		Click(field);
 		App.Keyboard.Press(Hexa.NET.ImGui.ImGuiKey.A, ctrl: true);
 		App.Keyboard.Type(text);
+	}
+
+	/// <summary>
+	/// Types a value into a marked single-line field and finishes the edit.
+	/// </summary>
+	/// <remarks>
+	/// The edit has to be finished for anything to happen: <see cref="EditField"/> reports a value
+	/// to write only on the frame the field is deactivated having been changed, which is what keeps
+	/// an editing session to one undo entry. Enter is how a single-line field is left; a
+	/// multi-line one takes the Enter as a newline and has to be left by clicking away from it.
+	/// </remarks>
+	/// <param name="field">A marked name, or the trailing part of one.</param>
+	/// <param name="text">The text to leave in the field.</param>
+	internal void Commit(string field, string text)
+	{
+		TypeInto(field, text);
+		App.Keyboard.Press(Hexa.NET.ImGui.ImGuiKey.Enter);
+		App.Step(2);
 	}
 
 	public void Dispose()

--- a/SchemaEditor.Test/ElementPanelTests.cs
+++ b/SchemaEditor.Test/ElementPanelTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
 using ktsu.Semantics.Strings;
 
 using SchemaTypes = ktsu.Schema.Models.Types;
@@ -120,6 +121,12 @@ public sealed class ElementPanelTests
 		Assert.AreEqual("Where an order has got to.", status.Description.ToString());
 	}
 
+	/// <summary>
+	/// The expected value is built through the same conversion the panel puts the typed text
+	/// through, rather than written out as a string: a relative path normalises its separators to
+	/// the platform's, so a literal "data/users.json" is what the field holds on Linux and not on
+	/// Windows. What this is about is the typed value reaching the model, not how a path is spelt.
+	/// </summary>
 	[TestMethod]
 	public void SettingADataSourcesFilePathRecordsIt()
 	{
@@ -128,7 +135,7 @@ public sealed class ElementPanelTests
 
 		harness.Commit("field/DataSourceFileUsers", "data/users.json");
 
-		Assert.AreEqual("data/users.json", users.File.ToString());
+		Assert.AreEqual("data/users.json".As<RelativeFilePath>(), users.File);
 	}
 
 	[TestMethod]

--- a/SchemaEditor.Test/ElementPanelTests.cs
+++ b/SchemaEditor.Test/ElementPanelTests.cs
@@ -1,0 +1,333 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System.Linq;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+/// <summary>
+/// The property panel for whichever element is selected: its name and description fields, and the
+/// pickers that point one element at another.
+/// </summary>
+/// <remarks>
+/// Everything here is reached the way a user reaches it - the field is clicked into, typed in and
+/// left, the picker is opened and an option chosen - because the behaviour being checked lives in
+/// what the widget reports across those frames rather than in the method it eventually calls.
+/// </remarks>
+[TestClass]
+public sealed class ElementPanelTests
+{
+	private EditorHarness harness = null!;
+	private Schema schema = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+		schema = new Schema();
+		harness.Editor.CurrentSchema = schema;
+	}
+
+	[TestCleanup]
+	public void StopEditor() => harness.Dispose();
+
+	private SchemaClass AddClass(string name) => schema.AddClass(name.As<ClassName>())!;
+
+	[TestMethod]
+	public void RenamingAClassFromItsPanelRenamesIt()
+	{
+		SchemaClass user = AddClass("User");
+		harness.Editor.EditClass(user);
+
+		harness.Commit("field/ClassNameUser", "Account");
+
+		Assert.AreEqual("Account", user.Name.ToString());
+		Assert.IsNotNull(schema.GetClass("Account".As<ClassName>()));
+	}
+
+	[TestMethod]
+	public void RenamingAClassFromItsPanelIsUndoable()
+	{
+		SchemaClass user = AddClass("User");
+		harness.Editor.EditClass(user);
+		harness.Commit("field/ClassNameUser", "Account");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual("User", user.Name.ToString());
+	}
+
+	/// <summary>
+	/// A name that collides with a sibling is refused with a message, and nothing is left on the
+	/// undo stack for a rename that never happened.
+	/// </summary>
+	[TestMethod]
+	public void RenamingAClassToANameAlreadyInUseIsRefused()
+	{
+		SchemaClass user = AddClass("User");
+		AddClass("Account");
+		harness.Editor.EditClass(user);
+
+		harness.Commit("field/ClassNameUser", "Account");
+		harness.App.Step(3);
+
+		Assert.AreEqual("User", user.Name.ToString());
+		Assert.IsTrue(harness.App.Probe.Matches("prompt/OK").Count > 0, "The collision was not reported.");
+		Assert.IsFalse(harness.Editor.UndoRedo.CanUndo, "A rename that was refused left an undo entry behind.");
+	}
+
+	/// <summary>
+	/// A description is multi-line, so the edit is finished by leaving the field rather than by
+	/// pressing Enter, which the field takes as a newline.
+	/// </summary>
+	[TestMethod]
+	public void EditingAClassDescriptionRecordsIt()
+	{
+		SchemaClass user = AddClass("User");
+		harness.Editor.EditClass(user);
+
+		harness.TypeInto("field/ClassDescriptionUser", "Someone with an account.");
+		harness.Click("field/ClassNameUser");
+
+		Assert.AreEqual("Someone with an account.", user.Description.ToString());
+	}
+
+	[TestMethod]
+	public void RenamingAnEnumFromItsPanelRenamesIt()
+	{
+		SchemaEnum status = schema.AddEnum("Status".As<EnumName>())!;
+		harness.Editor.EditEnum(status);
+
+		harness.Commit("field/EnumNameStatus", "State");
+
+		Assert.AreEqual("State", status.Name.ToString());
+	}
+
+	[TestMethod]
+	public void EditingAnEnumDescriptionRecordsIt()
+	{
+		SchemaEnum status = schema.AddEnum("Status".As<EnumName>())!;
+		harness.Editor.EditEnum(status);
+
+		harness.TypeInto("field/EnumDescriptionStatus", "Where an order has got to.");
+		harness.Click("field/EnumNameStatus");
+
+		Assert.AreEqual("Where an order has got to.", status.Description.ToString());
+	}
+
+	[TestMethod]
+	public void SettingADataSourcesFilePathRecordsIt()
+	{
+		DataSource users = schema.AddDataSource("Users".As<DataSourceName>())!;
+		harness.Editor.EditDataSource(users);
+
+		harness.Commit("field/DataSourceFileUsers", "data/users.json");
+
+		Assert.AreEqual("data/users.json", users.File.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingAClassForADataSourcePointsItAtThatClass()
+	{
+		AddClass("User");
+		DataSource users = schema.AddDataSource("Users".As<DataSourceName>())!;
+		harness.Editor.EditDataSource(users);
+
+		harness.Click("class-selector/Users");
+		harness.Click("class-option/User");
+
+		Assert.AreEqual("User", users.ClassName.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingNoClassForADataSourceClearsIt()
+	{
+		AddClass("User");
+		DataSource users = schema.AddDataSource("Users".As<DataSourceName>())!;
+		users.ClassName = "User".As<ClassName>();
+		harness.Editor.EditDataSource(users);
+
+		harness.Click("class-selector/Users");
+		harness.Click("class-option/<none>");
+
+		Assert.AreEqual(string.Empty, users.ClassName.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingAClassForADataSourceIsUndoable()
+	{
+		AddClass("User");
+		DataSource users = schema.AddDataSource("Users".As<DataSourceName>())!;
+		harness.Editor.EditDataSource(users);
+		harness.Click("class-selector/Users");
+		harness.Click("class-option/User");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual(string.Empty, users.ClassName.ToString());
+	}
+
+	[TestMethod]
+	public void RenamingAMemberFromItsRowRenamesIt()
+	{
+		SchemaClass user = AddClass("User");
+		SchemaMember id = user.AddMember("Id".As<MemberName>())!;
+		harness.Editor.EditClass(user);
+
+		harness.Commit("memberId/field/Name", "Identifier");
+
+		Assert.AreEqual("Identifier", id.Name.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingAMemberTypeSetsIt()
+	{
+		SchemaClass user = AddClass("User");
+		SchemaMember id = user.AddMember("Id".As<MemberName>())!;
+		harness.Editor.EditClass(user);
+
+		harness.Click("memberId/Type");
+		harness.Click("searchable-list/String");
+
+		Assert.AreEqual("String", id.Type.DisplayName);
+	}
+
+	[TestMethod]
+	public void ChoosingAMemberTypeIsUndoable()
+	{
+		SchemaClass user = AddClass("User");
+		SchemaMember id = user.AddMember("Id".As<MemberName>())!;
+		id.SetType(new SchemaTypes.Int());
+		harness.Editor.EditClass(user);
+
+		harness.Click("memberId/Type");
+		harness.Click("searchable-list/String");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual("Int", id.Type.DisplayName);
+	}
+
+	/// <summary>
+	/// The container is only asked for on an array member, and is the one field the editor used to
+	/// write to the model on every frame it was drawn.
+	/// </summary>
+	[TestMethod]
+	public void SettingAnArraysContainerRecordsIt()
+	{
+		SchemaClass user = AddClass("User");
+		SchemaMember tags = user.AddMember("Tags".As<MemberName>())!;
+		tags.SetType(new SchemaTypes.Array() { ElementType = new SchemaTypes.String() });
+		harness.Editor.EditClass(user);
+
+		harness.Commit("memberTags/field/Container", "HashSet");
+
+		Assert.AreEqual("HashSet", ((SchemaTypes.Array)tags.Type).Container.ToString());
+	}
+
+	/// <summary>
+	/// An array of objects can be keyed by one of the element class's primitive members, which is
+	/// the only case the key picker is offered in.
+	/// </summary>
+	[TestMethod]
+	public void ChoosingAnArrayKeySetsIt()
+	{
+		SchemaClass user = AddClass("User");
+		user.AddMember("Id".As<MemberName>())!.SetType(new SchemaTypes.Int());
+
+		SchemaClass account = AddClass("Account");
+		SchemaMember owners = account.AddMember("Owners".As<MemberName>())!;
+		owners.SetType(new SchemaTypes.Array() { ElementType = new SchemaTypes.Object() { ClassName = user.Name } });
+		harness.Editor.EditClass(account);
+
+		harness.Click("memberOwners/KeySelector");
+		harness.Click("key-option/Id");
+
+		Assert.AreEqual("Id", ((SchemaTypes.Array)owners.Type).Key.ToString());
+	}
+
+	[TestMethod]
+	public void ChoosingNoArrayKeyClearsIt()
+	{
+		SchemaClass user = AddClass("User");
+		user.AddMember("Id".As<MemberName>())!.SetType(new SchemaTypes.Int());
+
+		SchemaClass account = AddClass("Account");
+		SchemaMember owners = account.AddMember("Owners".As<MemberName>())!;
+		SchemaTypes.Array array = new() { ElementType = new SchemaTypes.Object() { ClassName = user.Name }, Key = "Id".As<MemberName>() };
+		owners.SetType(array);
+		harness.Editor.EditClass(account);
+
+		harness.Click("memberOwners/KeySelector");
+		harness.Click("key-option/<none>");
+
+		Assert.AreEqual(string.Empty, array.Key.ToString());
+	}
+
+	/// <summary>
+	/// A member's description is folded away until its arrow is opened, so that a class with a
+	/// dozen members is still a grid rather than a wall of text boxes.
+	/// </summary>
+	[TestMethod]
+	public void AMemberDescriptionIsHiddenUntilItsRowIsOpened()
+	{
+		SchemaClass user = AddClass("User");
+		user.AddMember("Id".As<MemberName>());
+		harness.Editor.EditClass(user);
+		harness.App.Step(2);
+
+		Assert.IsFalse(
+			harness.App.Probe.KnownNames.Any(name => name.Contains("field/MemberDescription", StringComparison.Ordinal)),
+			"The description editor was drawn before the row was opened.");
+	}
+
+	[TestMethod]
+	public void OpeningAMemberRowShowsItsDescriptionEditor()
+	{
+		SchemaClass user = AddClass("User");
+		user.AddMember("Id".As<MemberName>());
+		harness.Editor.EditClass(user);
+
+		harness.Click("memberId/ToggleDescription");
+
+		Assert.IsTrue(harness.App.Probe.Matches("field/MemberDescriptionUser.Id").Count > 0, "The description editor was not drawn.");
+	}
+
+	/// <summary>
+	/// Which rows are open is remembered rather than reset per frame, so the arrow closes what it
+	/// opened.
+	/// </summary>
+	[TestMethod]
+	public void ClosingAMemberRowHidesItsDescriptionEditorAgain()
+	{
+		SchemaClass user = AddClass("User");
+		user.AddMember("Id".As<MemberName>());
+		harness.Editor.EditClass(user);
+		harness.Click("memberId/ToggleDescription");
+
+		harness.Click("memberId/ToggleDescription");
+
+		Assert.IsFalse(
+			harness.IsOnScreen("field/MemberDescriptionUser.Id"),
+			"The description editor was still being drawn after the row was closed.");
+	}
+
+	[TestMethod]
+	public void EditingAMemberDescriptionRecordsIt()
+	{
+		SchemaClass user = AddClass("User");
+		SchemaMember id = user.AddMember("Id".As<MemberName>())!;
+		harness.Editor.EditClass(user);
+		harness.Click("memberId/ToggleDescription");
+
+		harness.TypeInto("field/MemberDescriptionUser.Id", "What identifies the user.");
+		harness.Click("memberId/field/Name");
+
+		Assert.AreEqual("What identifies the user.", id.Description.ToString());
+	}
+}

--- a/SchemaEditor.Test/FileBrowserTests.cs
+++ b/SchemaEditor.Test/FileBrowserTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+/// <summary>
+/// Saving through the file browser, which is the only path that answers over later frames.
+/// </summary>
+/// <remarks>
+/// A document with no path cannot be saved without asking where to put it, and the browser answers
+/// whenever the user gets round to it. Everything the save was standing in the way of - replacing
+/// the document, closing the editor - has to wait for that answer and then happen, which is what
+/// the continuation carried through <see cref="SchemaEditor.SaveThen"/> is for. The browser opens
+/// on the working directory, so these tests make their scratch directory the working directory
+/// rather than clicking their way there.
+/// </remarks>
+[TestClass]
+public sealed class FileBrowserTests
+{
+	private EditorHarness harness = null!;
+	private AbsoluteDirectoryPath scratchDirectory = null!;
+	private string previousWorkingDirectory = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-editor-browser-tests-{Guid.NewGuid():N}".As<DirectoryName>();
+		Directory.CreateDirectory(scratchDirectory);
+
+		previousWorkingDirectory = Directory.GetCurrentDirectory();
+		Directory.SetCurrentDirectory(scratchDirectory);
+
+		harness = EditorHarness.Start();
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		harness.Dispose();
+		Directory.SetCurrentDirectory(previousWorkingDirectory);
+
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	/// <summary>
+	/// Answers the browser with a file name, which it takes as a file in the directory it is
+	/// showing.
+	/// </summary>
+	private void AnswerBrowserWith(string fileName)
+	{
+		harness.StepUntil(() => harness.App.Probe.Matches("filesystem-browser/filename").Count > 0, "the save browser appearing");
+		harness.TypeInto("filesystem-browser/filename", fileName);
+		harness.Click("filesystem-browser/confirm");
+		harness.App.Step(2);
+	}
+
+	private Schema OpenDirtyDocument()
+	{
+		Schema schema = new();
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.Execute(new DelegateCommand(
+			"Add Class",
+			() => schema.TryAddClass("User".As<ClassName>()),
+			() => schema.RemoveClass("User".As<ClassName>()),
+			ChangeType.Insert));
+
+		return schema;
+	}
+
+	[TestMethod]
+	public void SavingADocumentWithNoPathWritesItWhereTheBrowserSays()
+	{
+		OpenDirtyDocument();
+
+		harness.Editor.SaveThen(null);
+		AnswerBrowserWith("chosen.schema.json");
+
+		Assert.IsTrue(File.Exists(scratchDirectory / "chosen.schema.json".As<FileName>()), "The document was not written where the browser was pointed.");
+		Assert.AreEqual("chosen.schema.json", harness.Editor.DocumentName, "The document did not take the path it was saved to.");
+		Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+	}
+
+	/// <summary>
+	/// The continuation is the whole point of the deferral: what the user was doing when the
+	/// unsaved-changes prompt appeared has to happen once the save finally lands.
+	/// </summary>
+	[TestMethod]
+	public void TheActionTheSaveWasGuardingRunsOnceTheBrowserAnswers()
+	{
+		OpenDirtyDocument();
+		bool proceeded = false;
+
+		harness.Editor.SaveThen(() => proceeded = true);
+		Assert.IsFalse(proceeded, "The action ran before the browser had been answered.");
+
+		AnswerBrowserWith("guarded.schema.json");
+
+		Assert.IsTrue(proceeded, "The action never ran, though the save succeeded.");
+	}
+
+	[TestMethod]
+	public void SavingRecordsTheChosenPathAsRecentlyUsed()
+	{
+		OpenDirtyDocument();
+
+		harness.Editor.SaveThen(null);
+		AnswerBrowserWith("recorded.schema.json");
+
+		Assert.AreEqual(scratchDirectory / "recorded.schema.json".As<FileName>(), harness.Editor.Options.RecentFiles[0]);
+	}
+
+	/// <summary>
+	/// Saving from the unsaved-changes prompt is the case that stacks both deferrals: the prompt
+	/// answers on one frame, the browser on a later one, and only then may the document be
+	/// replaced.
+	/// </summary>
+	[TestMethod]
+	public void SavingFromTheUnsavedChangesPromptDefersUntilTheBrowserAnswers()
+	{
+		Schema dirty = OpenDirtyDocument();
+
+		harness.Editor.New();
+		harness.Click("prompt/Save");
+
+		Assert.AreSame(dirty, harness.Editor.CurrentSchema, "The document was replaced before it had been saved anywhere.");
+
+		AnswerBrowserWith("stacked.schema.json");
+
+		Assert.AreNotSame(dirty, harness.Editor.CurrentSchema, "The document was never replaced, though the save succeeded.");
+		Assert.IsTrue(File.Exists(scratchDirectory / "stacked.schema.json".As<FileName>()));
+	}
+
+	/// <summary>
+	/// Backing out of the browser leaves the document exactly as it was, rather than half-applying
+	/// whatever the save was standing in the way of.
+	/// </summary>
+	[TestMethod]
+	public void CancellingTheBrowserLeavesTheDocumentAlone()
+	{
+		Schema dirty = OpenDirtyDocument();
+		bool proceeded = false;
+
+		harness.Editor.SaveThen(() => proceeded = true);
+		harness.StepUntil(() => harness.App.Probe.Matches("filesystem-browser/cancel").Count > 0, "the save browser appearing");
+		harness.Click("filesystem-browser/cancel");
+
+		Assert.IsFalse(proceeded);
+		Assert.AreSame(dirty, harness.Editor.CurrentSchema);
+		Assert.IsTrue(harness.Editor.HasUnsavedChanges);
+		Assert.AreEqual(string.Empty, harness.Editor.CurrentSchemaPath.ToString());
+	}
+}

--- a/SchemaEditor.Test/MenuTests.cs
+++ b/SchemaEditor.Test/MenuTests.cs
@@ -1,0 +1,264 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+/// <summary>
+/// The application menus, driven the way a user reaches them: the menu is opened and the item is
+/// clicked.
+/// </summary>
+/// <remarks>
+/// New, Open, Save and Exit have always been reachable two ways - from the File menu and from a
+/// keyboard shortcut - and only the second was ever exercised, because a menu item had no name a
+/// test could click. So the enabling rules, which live only in the menu, went unchecked: whether
+/// Save is offered with no document open, and whether Open Externally is offered with no path.
+/// </remarks>
+[TestClass]
+public sealed class MenuTests
+{
+	private EditorHarness harness = null!;
+	private AbsoluteDirectoryPath scratchDirectory = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+
+		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-editor-menu-tests-{Guid.NewGuid():N}".As<DirectoryName>();
+		Directory.CreateDirectory(scratchDirectory);
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		harness.Dispose();
+
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	private AbsoluteFilePath ScratchFile(string name) => scratchDirectory / name.As<FileName>();
+
+	/// <summary>
+	/// Opens a document and makes an edit through the undo service, which is what the unsaved
+	/// marker and the Edit menu both read.
+	/// </summary>
+	private Schema OpenDirtyDocument()
+	{
+		Schema schema = new();
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.Execute(new DelegateCommand(
+			"Add Class",
+			() => schema.TryAddClass("User".As<ClassName>()),
+			() => schema.RemoveClass("User".As<ClassName>()),
+			ChangeType.Insert));
+
+		return schema;
+	}
+
+	/// <summary>
+	/// Whether a popup the editor raises is on screen, named by the marks its buttons carry.
+	/// </summary>
+	private bool IsShowing(string item) => harness.App.Probe.Matches(item).Count > 0;
+
+	[TestMethod]
+	public void NewFromTheFileMenuReplacesTheDocument()
+	{
+		Schema first = new();
+		harness.Editor.CurrentSchema = first;
+
+		harness.ChooseMenuItem("File", "New");
+
+		Assert.IsNotNull(harness.Editor.CurrentSchema);
+		Assert.AreNotSame(first, harness.Editor.CurrentSchema);
+	}
+
+	[TestMethod]
+	public void NewFromTheFileMenuAsksBeforeDiscardingUnsavedWork()
+	{
+		Schema dirty = OpenDirtyDocument();
+
+		harness.ChooseMenuItem("File", "New");
+		harness.App.Step(3);
+
+		Assert.AreSame(dirty, harness.Editor.CurrentSchema, "The document was replaced without the user being asked.");
+		Assert.IsTrue(IsShowing("prompt/Discard"), "The unsaved-changes prompt was not raised.");
+	}
+
+	[TestMethod]
+	public void OpenFromTheFileMenuRaisesTheFileBrowser()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+
+		harness.ChooseMenuItem("File", "Open");
+		harness.App.Step(4);
+
+		Assert.IsTrue(IsShowing("filesystem-browser/cancel"), "The open browser was not raised.");
+	}
+
+	[TestMethod]
+	public void SaveFromTheFileMenuWritesTheDocument()
+	{
+		OpenDirtyDocument();
+		AbsoluteFilePath path = ScratchFile("menu-save.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+
+		harness.ChooseMenuItem("File", "Save");
+
+		Assert.IsTrue(File.Exists(path));
+		Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+	}
+
+	/// <summary>
+	/// There is nothing to save with no document open, and the menu says so by disabling the item
+	/// rather than by offering one that fails.
+	/// </summary>
+	[TestMethod]
+	public void SaveIsNotOfferedWithNoDocumentOpen()
+	{
+		Assert.IsNull(harness.Editor.CurrentSchema, "This test is about the menu with no document behind it.");
+
+		harness.ChooseMenuItem("File", "Save");
+		harness.App.Step(4);
+
+		Assert.IsFalse(IsShowing("filesystem-browser/cancel"), "A disabled Save asked where to put a document that does not exist.");
+	}
+
+	[TestMethod]
+	public void SaveAsFromTheFileMenuAsksWhereToPutTheDocument()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+
+		harness.ChooseMenuItem("File", "Save As...");
+		harness.App.Step(4);
+
+		Assert.IsTrue(IsShowing("filesystem-browser/cancel"), "The save browser was not raised.");
+	}
+
+	/// <summary>
+	/// Opening the schema in whatever the operating system associates with it needs a path, and
+	/// the item is disabled until there is one.
+	/// </summary>
+	/// <remarks>
+	/// The two-argument ImGui overload this item used to call takes its flag as the item's checked
+	/// state rather than as whether it is enabled, so it stayed clickable with no document open and
+	/// handed the shell an empty path, which failed into an error popup.
+	/// </remarks>
+	[TestMethod]
+	public void OpenExternallyIsNotOfferedWithoutAPath()
+	{
+		Assert.AreEqual(string.Empty, harness.Editor.CurrentSchemaPath.ToString());
+
+		harness.ChooseMenuItem("File", "Open Externally");
+		harness.App.Step(4);
+
+		Assert.IsFalse(IsShowing("prompt/OK"), "A disabled Open Externally handed an empty path to the shell.");
+	}
+
+	[TestMethod]
+	public void ExitFromTheFileMenuAsksAboutUnsavedWork()
+	{
+		OpenDirtyDocument();
+
+		harness.ChooseMenuItem("File", "Exit");
+		harness.App.Step(3);
+
+		Assert.IsTrue(IsShowing("prompt/Discard"), "Exiting offered to throw the document away without asking.");
+	}
+
+	[TestMethod]
+	public void TheRecentFilesMenuListsADocumentThatIsStillThere()
+	{
+		AbsoluteFilePath path = ScratchFile("listed.schema.json");
+		File.WriteAllText(path, SchemaSerializer.Serialize(new Schema()));
+		harness.Editor.Options.RecordRecentFile(path);
+
+		harness.ChooseMenuItem("File", "Open Recent");
+
+		Assert.IsTrue(IsShowing("recent/listed.schema.json"));
+	}
+
+	/// <summary>
+	/// A file on a drive that is not mounted right now is skipped rather than forgotten, so the
+	/// menu lists what can actually be opened and keeps the rest for when it comes back.
+	/// </summary>
+	[TestMethod]
+	public void TheRecentFilesMenuSkipsADocumentThatIsNotThere()
+	{
+		AbsoluteFilePath missing = ScratchFile("gone.schema.json");
+		harness.Editor.Options.RecordRecentFile(missing);
+
+		harness.ChooseMenuItem("File", "Open Recent");
+
+		Assert.IsFalse(IsShowing("recent/gone.schema.json"), "A file that is not on disk was offered.");
+		Assert.AreEqual(missing, harness.Editor.Options.RecentFiles[0], "It should still be remembered for when it comes back.");
+	}
+
+	[TestMethod]
+	public void OpeningARecentFileLoadsIt()
+	{
+		Schema source = new();
+		source.AddClass("Recalled".As<ClassName>());
+		AbsoluteFilePath path = ScratchFile("recalled.schema.json");
+		File.WriteAllText(path, SchemaSerializer.Serialize(source));
+		harness.Editor.Options.RecordRecentFile(path);
+
+		harness.ChooseMenuItem("File", "Open Recent");
+		harness.Click("recent/recalled.schema.json");
+
+		Assert.AreEqual(path, harness.Editor.CurrentSchemaPath);
+		Assert.AreEqual("Recalled", harness.Editor.CurrentClass?.Name.ToString());
+	}
+
+	[TestMethod]
+	public void UndoFromTheEditMenuRevertsTheLastEdit()
+	{
+		Schema schema = OpenDirtyDocument();
+		Assert.IsNotNull(schema.GetClass("User".As<ClassName>()));
+
+		harness.ChooseMenuItem("Edit", "Undo");
+
+		Assert.IsNull(schema.GetClass("User".As<ClassName>()));
+	}
+
+	[TestMethod]
+	public void RedoFromTheEditMenuAppliesTheEditAgain()
+	{
+		Schema schema = OpenDirtyDocument();
+		harness.ChooseMenuItem("Edit", "Undo");
+
+		harness.ChooseMenuItem("Edit", "Redo");
+
+		Assert.IsNotNull(schema.GetClass("User".As<ClassName>()));
+	}
+
+	/// <summary>
+	/// With nothing on the undo stack there is nothing to undo, and the item is disabled rather
+	/// than offered.
+	/// </summary>
+	[TestMethod]
+	public void UndoIsNotOfferedWithNothingToUndo()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		Assert.IsFalse(harness.Editor.UndoRedo.CanUndo);
+
+		harness.ChooseMenuItem("Edit", "Undo");
+
+		Assert.IsFalse(harness.Editor.UndoRedo.CanRedo, "A disabled Undo ran, leaving something to redo.");
+	}
+}

--- a/SchemaEditor.Test/SchemaFileTests.cs
+++ b/SchemaEditor.Test/SchemaFileTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// Reading and writing the document on disk, and what each failure is reported as.
+/// </summary>
+/// <remarks>
+/// The reason a load failed is not decoration: a file written by a newer build of the library is
+/// not a broken file, and the editor titles its message differently for each. Nothing here needs a
+/// frame - this is the one part of the editor that was always plain logic.
+/// </remarks>
+[TestClass]
+public sealed class SchemaFileTests
+{
+	private AbsoluteDirectoryPath scratchDirectory = null!;
+
+	[TestInitialize]
+	public void CreateScratchDirectory()
+	{
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-file-tests-{Guid.NewGuid():N}".As<DirectoryName>();
+		Directory.CreateDirectory(scratchDirectory);
+	}
+
+	[TestCleanup]
+	public void DeleteScratchDirectory()
+	{
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	private AbsoluteFilePath ScratchFile(string name) => scratchDirectory / name.As<FileName>();
+
+	[TestMethod]
+	public void ASchemaRoundTripsThroughAFile()
+	{
+		Schema source = new();
+		source.AddClass("User".As<ClassName>());
+		AbsoluteFilePath path = ScratchFile("round-trip.schema.json");
+
+		Assert.IsTrue(SchemaFile.TrySave(source, path));
+		Assert.IsTrue(SchemaFile.TryLoad(path, out Schema? loaded));
+
+		Assert.IsNotNull(loaded);
+		Assert.IsNotNull(loaded.GetClass("User".As<ClassName>()));
+	}
+
+	/// <summary>
+	/// Saving creates the directories the path names, so a schema can be saved into a folder that
+	/// does not exist yet.
+	/// </summary>
+	[TestMethod]
+	public void SavingCreatesTheDirectoryTheFileGoesIn()
+	{
+		AbsoluteFilePath path = scratchDirectory / "nested".As<DirectoryName>() / "made.schema.json".As<FileName>();
+
+		Assert.IsTrue(SchemaFile.TrySave(new Schema(), path));
+		Assert.IsTrue(File.Exists(path));
+	}
+
+	[TestMethod]
+	public void SavingWithNoPathFails() =>
+		Assert.IsFalse(SchemaFile.TrySave(new Schema(), new AbsoluteFilePath()));
+
+	/// <summary>
+	/// A path whose parent is an existing file rather than a directory cannot be created, which is
+	/// the failure the editor turns into its "failed to save" message.
+	/// </summary>
+	[TestMethod]
+	public void SavingWhereADirectoryCannotBeMadeFails()
+	{
+		const string blockerName = "blocker";
+		File.WriteAllText(ScratchFile(blockerName), "not a directory");
+		AbsoluteFilePath path = scratchDirectory / blockerName.As<DirectoryName>() / "nested.schema.json".As<FileName>();
+
+		Assert.IsFalse(SchemaFile.TrySave(new Schema(), path));
+	}
+
+	[TestMethod]
+	public void LoadingWithNoPathSaysSo()
+	{
+		SchemaLoadResult result = SchemaFile.Load(new AbsoluteFilePath());
+
+		Assert.IsFalse(result.IsSuccess);
+		Assert.IsNull(result.Schema);
+	}
+
+	[TestMethod]
+	public void LoadingAFileThatIsNotThereSaysSo()
+	{
+		SchemaLoadResult result = SchemaFile.Load(ScratchFile("absent.schema.json"));
+
+		Assert.IsFalse(result.IsSuccess);
+		Assert.IsTrue(result.Message.Contains("does not exist", StringComparison.Ordinal), $"The reason was '{result.Message}'.");
+	}
+
+	[TestMethod]
+	public void LoadingSomethingThatIsNotASchemaSaysSo()
+	{
+		AbsoluteFilePath path = ScratchFile("nonsense.schema.json");
+		File.WriteAllText(path, "{ this is not json");
+
+		SchemaLoadResult result = SchemaFile.Load(path);
+
+		Assert.IsFalse(result.IsSuccess);
+		Assert.AreEqual(SchemaLoadStatus.InvalidJson, result.Status);
+	}
+
+	/// <summary>
+	/// The failing load must not be reported through the out parameter as a schema, or the editor
+	/// would replace the open document with nothing.
+	/// </summary>
+	[TestMethod]
+	public void TryLoadReportsFailureWithoutASchema()
+	{
+		Assert.IsFalse(SchemaFile.TryLoad(ScratchFile("absent.schema.json"), out Schema? schema));
+		Assert.IsNull(schema);
+	}
+}

--- a/SchemaEditor.Test/ShortcutTests.cs
+++ b/SchemaEditor.Test/ShortcutTests.cs
@@ -1,0 +1,190 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using System;
+using System.IO;
+
+using Hexa.NET.ImGui;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Paths;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+/// <summary>
+/// The keyboard shortcuts, pressed into a live frame rather than by calling what they invoke.
+/// </summary>
+/// <remarks>
+/// The shortcuts are read from ImGui's own key state during the update callback, so what is being
+/// checked here is not only that Ctrl+S saves: it is that the editor sees the key at all, that
+/// Ctrl+Shift+S is not also taken as Ctrl+S, and that a shortcut does not fire while the key is
+/// going into a text field the user is typing in.
+/// </remarks>
+[TestClass]
+public sealed class ShortcutTests
+{
+	private EditorHarness harness = null!;
+	private AbsoluteDirectoryPath scratchDirectory = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+
+		// A real directory, not the in-memory one: SchemaFile saves through System.IO directly.
+		scratchDirectory = Path.GetTempPath().As<AbsoluteDirectoryPath>() / $"schema-editor-shortcut-tests-{Guid.NewGuid():N}".As<DirectoryName>();
+		Directory.CreateDirectory(scratchDirectory);
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		harness.Dispose();
+
+		try
+		{
+			Directory.Delete(scratchDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temporary directory is not worth failing a passing test over.
+		}
+	}
+
+	private AbsoluteFilePath ScratchFile(string name) => scratchDirectory / name.As<FileName>();
+
+	/// <summary>
+	/// Presses a shortcut and draws the frames that carry out what it started.
+	/// </summary>
+	private void Press(ImGuiKey key, bool shift = false)
+	{
+		harness.App.Keyboard.Press(key, ctrl: true, shift: shift);
+		harness.App.Step(3);
+	}
+
+	/// <summary>
+	/// Opens a document and makes one undoable edit, so there is something to undo and something
+	/// to lose.
+	/// </summary>
+	private Schema OpenDirtyDocument()
+	{
+		Schema schema = new();
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.Execute(new DelegateCommand(
+			"Add Class",
+			() => schema.TryAddClass("User".As<ClassName>()),
+			() => schema.RemoveClass("User".As<ClassName>()),
+			ChangeType.Insert));
+
+		return schema;
+	}
+
+	private bool IsShowing(string item) => harness.App.Probe.Matches(item).Count > 0;
+
+	[TestMethod]
+	public void CtrlNStartsANewDocument()
+	{
+		Schema first = new();
+		harness.Editor.CurrentSchema = first;
+
+		Press(ImGuiKey.N);
+
+		Assert.IsNotNull(harness.Editor.CurrentSchema);
+		Assert.AreNotSame(first, harness.Editor.CurrentSchema);
+	}
+
+	[TestMethod]
+	public void CtrlOAsksWhichDocumentToOpen()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+
+		Press(ImGuiKey.O);
+		harness.App.Step(3);
+
+		Assert.IsTrue(IsShowing("filesystem-browser/cancel"), "The open browser was not raised.");
+	}
+
+	[TestMethod]
+	public void CtrlSWritesTheDocument()
+	{
+		OpenDirtyDocument();
+		AbsoluteFilePath path = ScratchFile("shortcut-save.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+
+		Press(ImGuiKey.S);
+
+		Assert.IsTrue(File.Exists(path));
+		Assert.IsFalse(harness.Editor.HasUnsavedChanges);
+	}
+
+	/// <summary>
+	/// Save As has to be recognised before Save, or the shared S would save over the open file
+	/// instead of asking where the copy should go.
+	/// </summary>
+	[TestMethod]
+	public void CtrlShiftSAsksWhereToPutTheDocumentEvenWhenItHasAPath()
+	{
+		harness.Editor.CurrentSchema = new Schema();
+		AbsoluteFilePath path = ScratchFile("not-written.schema.json");
+		harness.Editor.CurrentSchemaPath = path;
+
+		Press(ImGuiKey.S, shift: true);
+		harness.App.Step(3);
+
+		Assert.IsTrue(IsShowing("filesystem-browser/cancel"), "The save browser was not raised.");
+		Assert.IsFalse(File.Exists(path), "Save As wrote to the open document's path without asking.");
+	}
+
+	[TestMethod]
+	public void CtrlZUndoesTheLastEdit()
+	{
+		Schema schema = OpenDirtyDocument();
+
+		Press(ImGuiKey.Z);
+
+		Assert.IsNull(schema.GetClass("User".As<ClassName>()));
+	}
+
+	[TestMethod]
+	public void CtrlShiftZRedoesIt()
+	{
+		Schema schema = OpenDirtyDocument();
+		Press(ImGuiKey.Z);
+
+		Press(ImGuiKey.Z, shift: true);
+
+		Assert.IsNotNull(schema.GetClass("User".As<ClassName>()));
+	}
+
+	[TestMethod]
+	public void CtrlYRedoesIt()
+	{
+		Schema schema = OpenDirtyDocument();
+		Press(ImGuiKey.Z);
+
+		Press(ImGuiKey.Y);
+
+		Assert.IsNotNull(schema.GetClass("User".As<ClassName>()));
+	}
+
+	/// <summary>
+	/// A shortcut must not fire while the key is going into a field, or typing an N into a class
+	/// name would throw the document away.
+	/// </summary>
+	[TestMethod]
+	public void ShortcutsAreIgnoredWhileAFieldIsBeingTypedInto()
+	{
+		Schema schema = new();
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.EditClass(user);
+
+		harness.Click("field/ClassNameUser");
+
+		Press(ImGuiKey.N);
+
+		Assert.AreSame(schema, harness.Editor.CurrentSchema, "Typing into a field started a new document.");
+	}
+}

--- a/SchemaEditor.Test/TreeContextMenuTests.cs
+++ b/SchemaEditor.Test/TreeContextMenuTests.cs
@@ -231,6 +231,46 @@ public sealed class TreeContextMenuTests
 	}
 
 	[TestMethod]
+	public void RenamingAnEnumValueChangesIt()
+	{
+		SchemaEnum colour = schema.GetEnum("Colour".As<EnumName>())!;
+		colour.TryAddValue("Red".As<EnumValueName>());
+
+		ChooseFromContextMenu("BtnRed", "RenameRed");
+		harness.TypeInto("input/field", "Crimson");
+		harness.Click("input/ok");
+
+		Assert.IsTrue(colour.Values.Any(v => v.ToString() == "Crimson"));
+		Assert.IsFalse(colour.Values.Any(v => v.ToString() == "Red"));
+	}
+
+	[TestMethod]
+	public void DeletingAnEnumValueRemovesIt()
+	{
+		SchemaEnum colour = schema.GetEnum("Colour".As<EnumName>())!;
+		colour.TryAddValue("Red".As<EnumValueName>());
+		colour.TryAddValue("Green".As<EnumValueName>());
+
+		ChooseFromContextMenu("BtnRed", "DeleteRed");
+
+		string[] remaining = [.. colour.Values.Select(v => v.ToString())];
+		Assert.AreEqual(1, remaining.Length, $"Values were [{string.Join(", ", remaining)}].");
+		Assert.AreEqual("Green", remaining[0]);
+	}
+
+	[TestMethod]
+	public void UndoingAnEnumValueDeleteBringsItBack()
+	{
+		SchemaEnum colour = schema.GetEnum("Colour".As<EnumName>())!;
+		colour.TryAddValue("Red".As<EnumValueName>());
+
+		ChooseFromContextMenu("BtnRed", "DeleteRed");
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.IsTrue(colour.Values.Any(v => v.ToString() == "Red"));
+	}
+
+	[TestMethod]
 	public void RenamingAMemberChangesItsName()
 	{
 		SchemaClass user = schema.GetClass("User".As<ClassName>())!;

--- a/SchemaEditor.Test/TreeEditingTests.cs
+++ b/SchemaEditor.Test/TreeEditingTests.cs
@@ -128,4 +128,64 @@ public sealed class TreeEditingTests
 
 		Assert.IsNotNull(schema.GetCodeGenerator("CSharp".As<CodeGeneratorName>()));
 	}
+
+	/// <summary>
+	/// Each tree refuses a name a sibling already has, rather than silently replacing it or adding
+	/// a second element nothing could tell apart.
+	/// </summary>
+	[TestMethod]
+	public void AddingAnEnumWithANameAlreadyInUseIsRefused()
+	{
+		schema.AddEnum("Colour".As<EnumName>());
+
+		AddNamed("NewEnum", "Colour");
+
+		Assert.AreEqual(1, schema.Enums.Count(e => e.Name.ToString() == "Colour"));
+	}
+
+	[TestMethod]
+	public void AddingAnEnumValueAlreadyInUseIsRefused()
+	{
+		SchemaEnum colour = schema.AddEnum("Colour".As<EnumName>())!;
+		colour.TryAddValue("Red".As<EnumValueName>());
+
+		AddNamed("NewValue", "Red");
+
+		Assert.AreEqual(1, colour.Values.Count(v => v.ToString() == "Red"));
+	}
+
+	[TestMethod]
+	public void AddingADataSourceWithANameAlreadyInUseIsRefused()
+	{
+		schema.AddDataSource("Users".As<DataSourceName>());
+		harness.SelectTree("Data Sources");
+
+		AddNamed("NewDataSource", "Users");
+
+		Assert.AreEqual(1, schema.DataSources.Count(d => d.Name.ToString() == "Users"));
+	}
+
+	[TestMethod]
+	public void AddingACodeGeneratorWithANameAlreadyInUseIsRefused()
+	{
+		schema.AddCodeGenerator("CSharp".As<CodeGeneratorName>());
+		harness.SelectTree("Code Generators");
+
+		AddNamed("NewCodeGenerator", "CSharp");
+
+		Assert.AreEqual(1, schema.CodeGenerators.Count(g => g.Name.ToString() == "CSharp"));
+	}
+
+	[TestMethod]
+	public void AddingAMemberWithANameAlreadyInUseIsRefused()
+	{
+		SchemaClass user = schema.AddClass("User".As<ClassName>())!;
+		user.AddMember("Age".As<MemberName>());
+		harness.Editor.EditClass(user);
+		harness.SelectTree("Classes");
+
+		AddNamed("User/NewMember", "Age");
+
+		Assert.AreEqual(1, user.Members.Count(m => m.Name.ToString() == "Age"));
+	}
 }

--- a/SchemaEditor.Test/WidgetHarness.cs
+++ b/SchemaEditor.Test/WidgetHarness.cs
@@ -3,6 +3,7 @@
 namespace ktsu.SchemaEditor.Test;
 
 using System;
+using System.IO.Abstractions.TestingHelpers;
 
 using ktsu.ImGui.App;
 using ktsu.ImGui.App.Testing;
@@ -11,11 +12,21 @@ using ktsu.ImGui.App.Testing;
 /// A headless ImGui frame with nothing in it but the widget under test.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Separate from <see cref="EditorHarness"/>, which drives the whole editor through the real
 /// application configuration. A widget like <see cref="EditField"/> is a unit below that: what is
 /// being tested is how it behaves across frames as ImGui reports the widget activating,
 /// being edited and deactivating, and putting the whole editor on screen to reach it would only
 /// add ways for the test to fail for reasons that are not the widget's.
+/// </para>
+/// <para>
+/// It also carries an editor, for a panel that belongs to one but sits behind a tab the editor
+/// cannot be asked to open - the widget library hosting the tabs neither records them for a probe
+/// nor takes a selection from outside. Drawing such a panel here reaches the same code the tab
+/// delegate runs. Its settings are redirected to an in-memory file system for the same reason
+/// <see cref="EditorHarness"/> redirects them: the editor otherwise reads and writes the settings
+/// of whoever runs the suite.
+/// </para>
 /// </remarks>
 internal sealed class WidgetHarness : IDisposable
 {
@@ -25,6 +36,12 @@ internal sealed class WidgetHarness : IDisposable
 	internal ImGuiAppHarness App { get; }
 
 	/// <summary>
+	/// Gets the editor a panel under test belongs to. Untouched by a test drawing a widget that
+	/// has nothing to do with the editor.
+	/// </summary>
+	internal SchemaEditor Editor { get; }
+
+	/// <summary>
 	/// Gets or sets what to draw each frame. Called from inside a live frame, so it may call ImGui
 	/// freely.
 	/// </summary>
@@ -32,7 +49,11 @@ internal sealed class WidgetHarness : IDisposable
 
 	private bool disposed;
 
-	private WidgetHarness(ImGuiAppHarness app) => App = app;
+	private WidgetHarness(ImGuiAppHarness app, SchemaEditor editor)
+	{
+		App = app;
+		Editor = editor;
+	}
 
 	/// <summary>
 	/// Starts a harness and advances the first frame, which builds the font atlas.
@@ -48,8 +69,12 @@ internal sealed class WidgetHarness : IDisposable
 			OnRender = _ => harness?.Draw(),
 		};
 
+		// Must precede the constructor: it is the constructor that loads the settings.
+		ktsu.AppDataStorage.AppData.ConfigureForTesting(() => new MockFileSystem());
+
+		SchemaEditor editor = new();
 		ImGuiAppHarness app = ImGuiAppHarness.Start(config, new HarnessOptions());
-		harness = new WidgetHarness(app);
+		harness = new WidgetHarness(app, editor);
 		app.Step();
 
 		return harness;
@@ -64,5 +89,6 @@ internal sealed class WidgetHarness : IDisposable
 
 		disposed = true;
 		App.Dispose();
+		ktsu.AppDataStorage.AppData.ResetFileSystem();
 	}
 }

--- a/SchemaEditor/ButtonTree.cs
+++ b/SchemaEditor/ButtonTree.cs
@@ -54,11 +54,23 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 	private static float RowWidth(string text) =>
 		MathF.Max(SchemaEditor.FieldWidth, ImGui.CalcTextSize(text).X + (ImGui.GetStyle().FramePadding.X * 2));
 
-	internal static void ShowTree(string id, string text, IEnumerable<TItem> items) => ShowTree(id, text, items, new(), null);
-	internal static void ShowTree(string id, string text, IEnumerable<TItem> items, Config config, ImGuiWidgets.Tree? parent)
+	/// <summary>
+	/// Draws a tree of rows, one button each.
+	/// </summary>
+	/// <remarks>
+	/// Takes the editor rather than reaching for <see cref="SchemaEditor.Instance"/>, because which
+	/// rows are folded open is part of that editor's settings.
+	/// </remarks>
+	/// <param name="editor">The editor the tree belongs to.</param>
+	/// <param name="id">A stable id for the tree, which is also what its folded state is keyed by.</param>
+	/// <param name="text">The tree's heading.</param>
+	/// <param name="items">The rows to draw.</param>
+	/// <param name="config">What each row does.</param>
+	/// <param name="parent">The tree this one hangs under, or null when it is a root.</param>
+	internal static void ShowTree(SchemaEditor editor, string id, string text, IEnumerable<TItem> items, Config config, ImGuiWidgets.Tree? parent)
 	{
 		bool isRoot = parent is null;
-		bool treeIsOpen = !isRoot || SchemaEditor.IsVisible(id);
+		bool treeIsOpen = !isRoot || editor.IsVisible(id);
 
 		if (isRoot)
 		{
@@ -71,7 +83,7 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 			ImGui.SameLine();
 			if (ImGui.ArrowButton($"##Arrow{id}", treeIsOpen ? ImGuiDir.Down : ImGuiDir.Up))
 			{
-				SchemaEditor.ToggleVisibility(id);
+				editor.ToggleVisibility(id);
 			}
 		}
 
@@ -83,7 +95,7 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 
 				foreach (TItem? item in items.ToCollection())
 				{
-					ShowTreeItem(id, config, tree, item);
+					ShowTreeItem(editor, id, config, tree, item);
 				}
 
 				config?.OnTreeEnd?.Invoke(tree);
@@ -112,13 +124,13 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 		}
 	}
 
-	private static void ShowTreeItem(string id, Config config, ImGuiWidgets.Tree tree, TItem? item)
+	private static void ShowTreeItem(SchemaEditor editor, string id, Config config, ImGuiWidgets.Tree tree, TItem? item)
 	{
 		if (item is not null)
 		{
 			string buttonText = config.GetText?.Invoke(item) ?? item.ToString() ?? string.Empty;
 			string itemId = config.GetId?.Invoke(item) ?? $"{id}.{buttonText}";
-			bool itemIsOpen = !config.Collapsible || SchemaEditor.IsVisible(itemId);
+			bool itemIsOpen = !config.Collapsible || editor.IsVisible(itemId);
 			using (tree.Child)
 			{
 				config.OnItemStart?.Invoke(tree, item);
@@ -168,7 +180,7 @@ internal sealed class ButtonTree<TItem> : ButtonTree
 					ImGui.SameLine();
 					if (ImGui.ArrowButton($"##Arrow{itemId}", itemIsOpen ? ImGuiDir.Down : ImGuiDir.Up))
 					{
-						SchemaEditor.ToggleVisibility(itemId);
+						editor.ToggleVisibility(itemId);
 					}
 				}
 			}

--- a/SchemaEditor/CodeGeneratorPanel.cs
+++ b/SchemaEditor/CodeGeneratorPanel.cs
@@ -6,6 +6,7 @@ using System.Numerics;
 
 using Hexa.NET.ImGui;
 
+using ktsu.ImGui.Probes;
 using ktsu.Schema.Generation;
 using ktsu.Schema.Models;
 using ktsu.Schema.Models.Names;
@@ -63,7 +64,9 @@ internal sealed class CodeGeneratorPanel(SchemaEditor schemaEditor)
 		}
 
 		ImGui.SameLine();
-		if (ImGui.Button($"Browse...##CodeGeneratorBrowse{codeGenerator.Name}"))
+		bool browse = ImGui.Button($"Browse...##CodeGeneratorBrowse{codeGenerator.Name}");
+		ImGuiProbes.MarkItem("browse", codeGenerator.Name);
+		if (browse)
 		{
 			SchemaCodeGenerator captured = codeGenerator;
 			Popups.OpenBrowserDirectory("Choose Output Directory", (directory) =>
@@ -84,6 +87,7 @@ internal sealed class CodeGeneratorPanel(SchemaEditor schemaEditor)
 	{
 		string label = string.IsNullOrEmpty(codeGenerator.Language) ? "<Select Language>" : codeGenerator.Language;
 		ImGui.Button($"{label}##CodeGeneratorLanguage{codeGenerator.Name}", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGuiProbes.MarkItem("language-selector", codeGenerator.Name);
 
 		if (!ImGui.BeginPopupContextItem($"##CodeGeneratorLanguageSelect{codeGenerator.Name}", ImGuiPopupFlags.MouseButtonLeft))
 		{
@@ -92,7 +96,9 @@ internal sealed class CodeGeneratorPanel(SchemaEditor schemaEditor)
 
 		foreach (string language in SchemaGenerator.SupportedLanguages)
 		{
-			if (ImGui.Selectable(language))
+			bool chosen = ImGui.Selectable(language);
+			ImGuiProbes.MarkItem("language-option", language);
+			if (chosen)
 			{
 				LanguageName previous = codeGenerator.Language;
 				LanguageName next = language.As<LanguageName>();
@@ -136,7 +142,9 @@ internal sealed class CodeGeneratorPanel(SchemaEditor schemaEditor)
 			return;
 		}
 
-		if (!ImGui.Button($"Generate##CodeGeneratorGenerate{codeGenerator.Name}"))
+		bool generate = ImGui.Button($"Generate##CodeGeneratorGenerate{codeGenerator.Name}");
+		ImGuiProbes.MarkItem("generate", codeGenerator.Name);
+		if (!generate)
 		{
 			return;
 		}

--- a/SchemaEditor/EditField.cs
+++ b/SchemaEditor/EditField.cs
@@ -7,6 +7,8 @@ using System.Numerics;
 
 using Hexa.NET.ImGui;
 
+using ktsu.ImGui.Probes;
+
 /// <summary>
 /// Text inputs that report a value to commit once per editing session rather than once per frame.
 /// </summary>
@@ -50,6 +52,7 @@ internal static class EditField
 
 		ImGui.SetNextItemWidth(width);
 		ImGui.InputText(id, ref buffer, (uint)maxLength);
+		Mark(id);
 
 		return Resolve(key, buffer, modelValue, out committed);
 	}
@@ -69,9 +72,22 @@ internal static class EditField
 		string buffer = Buffers.TryGetValue(key, out string? inProgress) ? inProgress : modelValue;
 
 		ImGui.InputTextMultiline(id, ref buffer, (uint)maxLength, size);
+		Mark(id);
 
 		return Resolve(key, buffer, modelValue, out committed);
 	}
+
+	/// <summary>
+	/// Records where the field was drawn, so a test can click into it.
+	/// </summary>
+	/// <remarks>
+	/// Every one of these is a hidden label - an id beginning with "##" so nothing is drawn beside
+	/// the box - which leaves a test no text to find it by. The id without its hashes is what the
+	/// caller already named the field, and any surrounding probe scope keeps two rows' fields
+	/// apart the same way <c>PushID</c> keeps them apart for ImGui.
+	/// </remarks>
+	/// <param name="id">The widget id the field was drawn with.</param>
+	private static void Mark(string id) => ImGuiProbes.MarkItem("field", id.TrimStart('#'));
 
 	/// <summary>
 	/// Decides, from the widget state ImGui reports for the item just drawn, whether the buffer

--- a/SchemaEditor/SchemaEditor.Diagnostics.cs
+++ b/SchemaEditor/SchemaEditor.Diagnostics.cs
@@ -9,6 +9,7 @@ using System.Linq;
 
 using Hexa.NET.ImGui;
 
+using ktsu.ImGui.Probes;
 using ktsu.Schema.Models;
 
 /// <summary>
@@ -70,7 +71,15 @@ public partial class SchemaEditor
 	/// </summary>
 	internal string DiagnosticsTabLabel => DiagnosticsTab.LabelOf(MainTabs, diagnosticsTabId);
 
-	private void ShowDiagnosticsPanel()
+	/// <summary>
+	/// Draws the issue list behind the diagnostics tab.
+	/// </summary>
+	/// <remarks>
+	/// Internal so a test can draw it directly. The tab bar hosting it comes from a widget library
+	/// that neither records its tabs for a probe nor takes a selection from outside, so there is no
+	/// tab for a test to click; drawing the panel is what the tab delegate does either way.
+	/// </remarks>
+	internal void ShowDiagnosticsPanel()
 	{
 		if (CurrentSchema is null)
 		{
@@ -110,7 +119,14 @@ public partial class SchemaEditor
 		ImGui.SameLine();
 
 		// Selectable rather than text so the whole row is a navigation target.
-		if (ImGui.Selectable($"{issue.Path}: {issue.Message}##{issue.Path}{issue.Message}"))
+		bool clicked = ImGui.Selectable($"{issue.Path}: {issue.Message}##{issue.Path}{issue.Message}");
+
+		// Severity and path rather than the whole row, so a test names the issue it means without
+		// repeating the wording of the message - and so that an element with both an error and a
+		// warning against it does not record two rows under one name.
+		ImGuiProbes.MarkItem("diagnostic", $"{issue.Severity}:{issue.Path}");
+
+		if (clicked)
 		{
 			NavigateTo(issue);
 		}

--- a/SchemaEditor/SchemaEditor.Files.cs
+++ b/SchemaEditor/SchemaEditor.Files.cs
@@ -11,6 +11,7 @@ using System.IO;
 using Hexa.NET.ImGui;
 
 using ktsu.ImGui.App;
+using ktsu.ImGui.Probes;
 using ktsu.Schema.Models;
 using ktsu.Semantics.Paths;
 
@@ -41,7 +42,7 @@ public partial class SchemaEditor
 	{
 		IReadOnlyList<AbsoluteFilePath> recent = [.. Options.RecentFiles];
 
-		if (!ImGui.BeginMenu("Open Recent", recent.Count > 0))
+		if (!BeginMenu("Open Recent", recent.Count > 0))
 		{
 			return;
 		}
@@ -57,7 +58,13 @@ public partial class SchemaEditor
 			}
 
 			anyShown = true;
-			if (ImGui.MenuItem(path))
+			bool clicked = ImGui.MenuItem(path);
+
+			// Recorded under the file name rather than the whole path, which a probe name would
+			// otherwise read as a chain of scopes because both are separated by slashes.
+			ImGuiProbes.MarkItem("recent", Path.GetFileName(path));
+
+			if (clicked)
 			{
 				AbsoluteFilePath captured = path;
 				WithUnsavedChangesGuard(() => LoadFrom(captured));

--- a/SchemaEditor/SchemaEditor.Panels.cs
+++ b/SchemaEditor/SchemaEditor.Panels.cs
@@ -197,20 +197,25 @@ public partial class SchemaEditor
 	{
 		string label = string.IsNullOrEmpty(dataSource.ClassName) ? "<Select Class>" : dataSource.ClassName;
 		ImGui.Button($"{label}##DataSourceClass{dataSource.Name}", new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("class-selector", dataSource.Name);
 
 		if (!ImGui.BeginPopupContextItem($"##DataSourceClassSelect{dataSource.Name}", ImGuiPopupFlags.MouseButtonLeft))
 		{
 			return;
 		}
 
-		if (ImGui.Selectable("<none>"))
+		bool none = ImGui.Selectable("<none>");
+		ImGuiProbes.MarkItem("class-option", "<none>");
+		if (none)
 		{
 			SetDataSourceClass(dataSource, new ClassName());
 		}
 
 		foreach (SchemaClass schemaClass in schema.Classes)
 		{
-			if (ImGui.Selectable(schemaClass.Name))
+			bool chosen = ImGui.Selectable(schemaClass.Name);
+			ImGuiProbes.MarkItem("class-option", schemaClass.Name);
+			if (chosen)
 			{
 				SetDataSourceClass(dataSource, schemaClass.Name);
 			}
@@ -293,7 +298,9 @@ public partial class SchemaEditor
 		ImGui.SameLine();
 		string descriptionKey = $"memberdescription:{schemaClass.Name}.{member.Name}";
 		bool descriptionOpen = !IsVisible(descriptionKey);
-		if (ImGui.ArrowButton("##ToggleDescription", descriptionOpen ? ImGuiDir.Down : ImGuiDir.Right))
+		bool toggleDescription = ImGui.ArrowButton("##ToggleDescription", descriptionOpen ? ImGuiDir.Down : ImGuiDir.Right);
+		ImGuiProbes.MarkItem("ToggleDescription");
+		if (toggleDescription)
 		{
 			ToggleVisibility(descriptionKey);
 		}
@@ -435,7 +442,9 @@ public partial class SchemaEditor
 		Ensure.NotNull(schema);
 		Ensure.NotNull(schemaMember);
 
-		if (ImGui.Button($"{schemaMember.Type.DisplayName}##Type", new Vector2(FieldWidth, 0)))
+		bool typeClicked = ImGui.Button($"{schemaMember.Type.DisplayName}##Type", new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("Type");
+		if (typeClicked)
 		{
 			SchemaMember captured = schemaMember;
 			Popups.OpenTypeList("Select Type", "Type", schema.GetAvailableTypes(), captured.Type, (type) => SetMemberType(captured, type));
@@ -478,20 +487,25 @@ public partial class SchemaEditor
 	private void ShowArrayKeySelector(SchemaTypes.Array array, SchemaClass elementClass)
 	{
 		ImGui.Button(string.IsNullOrEmpty(array.Key) ? "<none>" : array.Key, new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("KeySelector");
 
 		if (!ImGui.BeginPopupContextItem("##Key", ImGuiPopupFlags.MouseButtonLeft))
 		{
 			return;
 		}
 
-		if (ImGui.Selectable("<none>"))
+		bool none = ImGui.Selectable("<none>");
+		ImGuiProbes.MarkItem("key-option", "<none>");
+		if (none)
 		{
 			SetArrayKey(array, new MemberName());
 		}
 
 		foreach (SchemaMember primitiveMember in elementClass.Members.Where(m => m.Type.IsPrimitive).OrderBy(m => m.Name.ToString(), StringComparer.Ordinal))
 		{
-			if (ImGui.Selectable(primitiveMember.Name))
+			bool chosen = ImGui.Selectable(primitiveMember.Name);
+			ImGuiProbes.MarkItem("key-option", primitiveMember.Name);
+			if (chosen)
 			{
 				SetArrayKey(array, primitiveMember.Name);
 			}

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 
 using Hexa.NET.ImGui;
 
+using ktsu.ImGui.Probes;
 using ktsu.ImGui.Widgets;
 using ktsu.IntervalAction;
 using ktsu.Schema.Models;
@@ -285,19 +286,51 @@ public partial class SchemaEditor
 		}
 	}
 
+	/// <summary>
+	/// Opens a menu, recording where its header was drawn.
+	/// </summary>
+	/// <remarks>
+	/// ImGui gives a menu item no identity a probe can find on its own, so until the header and
+	/// the items under it were marked there was no way for a test to reach New, Open, Save or
+	/// Exit the way a user does - through the menu rather than by calling what it invokes.
+	/// </remarks>
+	/// <param name="label">The menu's label, which is also the name it is recorded under.</param>
+	/// <param name="enabled">Whether the menu can be opened.</param>
+	/// <returns>True while the menu is open, in which case it must be ended.</returns>
+	internal static bool BeginMenu(string label, bool enabled = true)
+	{
+		bool open = ImGui.BeginMenu(label, enabled);
+		ImGuiProbes.MarkItem("menu", label);
+		return open;
+	}
+
+	/// <summary>
+	/// Draws a menu item, recording where it was drawn.
+	/// </summary>
+	/// <param name="label">The item's label, which is also the name it is recorded under.</param>
+	/// <param name="shortcut">The keyboard shortcut shown beside it.</param>
+	/// <param name="enabled">Whether the item can be chosen.</param>
+	/// <returns>True on the frame it is clicked.</returns>
+	internal static bool MenuItem(string label, string shortcut = "", bool enabled = true)
+	{
+		bool clicked = ImGui.MenuItem(label, shortcut, false, enabled);
+		ImGuiProbes.MarkItem("menu", label);
+		return clicked;
+	}
+
 	private void ShowFileMenu()
 	{
-		if (!ImGui.BeginMenu("File"))
+		if (!BeginMenu("File"))
 		{
 			return;
 		}
 
-		if (ImGui.MenuItem("New", "Ctrl+N"))
+		if (MenuItem("New", "Ctrl+N"))
 		{
 			New();
 		}
 
-		if (ImGui.MenuItem("Open", "Ctrl+O"))
+		if (MenuItem("Open", "Ctrl+O"))
 		{
 			Open();
 		}
@@ -306,29 +339,33 @@ public partial class SchemaEditor
 
 		ImGui.Separator();
 
-		if (ImGui.MenuItem("Save", "Ctrl+S", false, CurrentSchema is not null))
+		if (MenuItem("Save", "Ctrl+S", CurrentSchema is not null))
 		{
 			Save();
 		}
 
 		// Always available while a schema is open: without it there is no way to save a copy
 		// somewhere else once the schema has a path.
-		if (ImGui.MenuItem("Save As...", "Ctrl+Shift+S", false, CurrentSchema is not null))
+		if (MenuItem("Save As...", "Ctrl+Shift+S", CurrentSchema is not null))
 		{
 			SaveAs();
 		}
 
 		ImGui.Separator();
 
+		// Enabled rather than selected: the two-argument ImGui overload this used to call takes
+		// the flag as the item's checked state, so the item was drawn with a tick beside it once
+		// the schema had a path, and stayed clickable - handing an empty path to the shell -
+		// while it had none.
 		string schemaFilePath = CurrentSchemaPath;
-		if (ImGui.MenuItem("Open Externally", !string.IsNullOrEmpty(schemaFilePath)))
+		if (MenuItem("Open Externally", string.Empty, !string.IsNullOrEmpty(schemaFilePath)))
 		{
 			OpenExternally(schemaFilePath);
 		}
 
 		ImGui.Separator();
 
-		if (ImGui.MenuItem("Exit"))
+		if (MenuItem("Exit"))
 		{
 			ExitWithUnsavedChangesGuard();
 		}
@@ -338,17 +375,17 @@ public partial class SchemaEditor
 
 	private void ShowEditMenu()
 	{
-		if (!ImGui.BeginMenu("Edit"))
+		if (!BeginMenu("Edit"))
 		{
 			return;
 		}
 
-		if (ImGui.MenuItem("Undo", "Ctrl+Z", false, UndoRedo.CanUndo))
+		if (MenuItem("Undo", "Ctrl+Z", UndoRedo.CanUndo))
 		{
 			Undo();
 		}
 
-		if (ImGui.MenuItem("Redo", "Ctrl+Y", false, UndoRedo.CanRedo))
+		if (MenuItem("Redo", "Ctrl+Y", UndoRedo.CanRedo))
 		{
 			Redo();
 		}
@@ -384,19 +421,35 @@ public partial class SchemaEditor
 		}
 	}
 
-	internal static bool ToggleVisibility(string key)
+	/// <summary>
+	/// Folds a collapsible part of the interface open or shut, and remembers which it now is.
+	/// </summary>
+	/// <remarks>
+	/// An instance member rather than a static one reaching for <see cref="Instance"/>. The state
+	/// belongs to the settings of the editor drawing the row, and while the application only ever
+	/// has one editor, a test has one per test - so reading it off the singleton meant a row left
+	/// open by one test came back open in the next.
+	/// </remarks>
+	/// <param name="key">What is being folded, as the caller names it.</param>
+	/// <returns>True if it is now hidden.</returns>
+	internal bool ToggleVisibility(string key)
 	{
-		Instance.QueueSaveOptions();
-		if (Instance.Options.HiddenItems.Remove(key))
+		QueueSaveOptions();
+		if (Options.HiddenItems.Remove(key))
 		{
 			return false;
 		}
 
-		Instance.Options.HiddenItems.Add(key);
+		Options.HiddenItems.Add(key);
 		return true;
 	}
 
-	internal static bool IsVisible(string key) => !Instance.Options.HiddenItems.Contains(key);
+	/// <summary>
+	/// Whether a collapsible part of the interface is folded open.
+	/// </summary>
+	/// <param name="key">What is being asked about, as the caller names it.</param>
+	/// <returns>True if it is not hidden.</returns>
+	internal bool IsVisible(string key) => !Options.HiddenItems.Contains(key);
 
 	private void ShowSchemaConfig()
 	{

--- a/SchemaEditor/TreeClass.cs
+++ b/SchemaEditor/TreeClass.cs
@@ -26,7 +26,7 @@ internal sealed class TreeClass(SchemaEditor schemaEditor)
 			IReadOnlyCollection<SchemaClass> children = schema.Classes;
 
 			string name = "Classes";
-			ButtonTree<SchemaClass>.ShowTree(name, $"{name} ({children.Count})", children, new()
+			ButtonTree<SchemaClass>.ShowTree(schemaEditor, name, $"{name} ({children.Count})", children, new()
 			{
 				Collapsible = true,
 				GetText = (x) => $"{x.Name} ({x.Members.Count})",
@@ -81,7 +81,7 @@ internal sealed class TreeClass(SchemaEditor schemaEditor)
 
 		ImGui.PushID(schemaClass.Name);
 		ImGuiProbes.PushScope(schemaClass.Name);
-		ButtonTree<SchemaMember>.ShowTree(schemaClass.Name, $"{schemaClass.Name} ({children.Count})", children, new()
+		ButtonTree<SchemaMember>.ShowTree(schemaEditor, schemaClass.Name, $"{schemaClass.Name} ({children.Count})", children, new()
 		{
 			GetText = (x) => x.Name,
 			GetTooltip = (x) => string.IsNullOrEmpty(x.Description)

--- a/SchemaEditor/TreeCodeGenerator.cs
+++ b/SchemaEditor/TreeCodeGenerator.cs
@@ -23,7 +23,7 @@ internal sealed class TreeCodeGenerator(SchemaEditor schemaEditor)
 			IReadOnlyCollection<SchemaCodeGenerator> children = schema.CodeGenerators;
 
 			string name = "Code Generators";
-			ButtonTree<SchemaCodeGenerator>.ShowTree(name, $"{name} ({children.Count})", children, new()
+			ButtonTree<SchemaCodeGenerator>.ShowTree(schemaEditor, name, $"{name} ({children.Count})", children, new()
 			{
 				Collapsible = true,
 				GetText = (x) => x.Name,

--- a/SchemaEditor/TreeDataSource.cs
+++ b/SchemaEditor/TreeDataSource.cs
@@ -23,7 +23,7 @@ internal sealed class TreeDataSource(SchemaEditor schemaEditor)
 			IReadOnlyCollection<DataSource> children = schema.DataSources;
 
 			string name = "DataSources";
-			ButtonTree<DataSource>.ShowTree(name, $"{name} ({children.Count})", children, new()
+			ButtonTree<DataSource>.ShowTree(schemaEditor, name, $"{name} ({children.Count})", children, new()
 			{
 				Collapsible = true,
 				GetText = (x) => x.Name,

--- a/SchemaEditor/TreeEnum.cs
+++ b/SchemaEditor/TreeEnum.cs
@@ -24,7 +24,7 @@ internal sealed class TreeEnum(SchemaEditor schemaEditor)
 			IReadOnlyCollection<SchemaEnum> children = schema.Enums;
 
 			string name = "Enums";
-			ButtonTree<SchemaEnum>.ShowTree(name, $"{name} ({children.Count})", children, new()
+			ButtonTree<SchemaEnum>.ShowTree(schemaEditor, name, $"{name} ({children.Count})", children, new()
 			{
 				Collapsible = true,
 				GetText = (x) => $"{x.Name} ({x.Values.Count})",
@@ -76,7 +76,7 @@ internal sealed class TreeEnum(SchemaEditor schemaEditor)
 	private void ShowEnumValueTree(ImGuiWidgets.Tree parent, SchemaEnum schemaEnum)
 	{
 		IReadOnlyCollection<EnumValueName> children = schemaEnum.Values;
-		ButtonTree<EnumValueName>.ShowTree(schemaEnum.Name, $"{schemaEnum.Name} ({children.Count})", children, new()
+		ButtonTree<EnumValueName>.ShowTree(schemaEditor, schemaEnum.Name, $"{schemaEnum.Name} ({children.Count})", children, new()
 		{
 			GetText = (x) => x,
 			GetId = (x) => x,
@@ -84,13 +84,17 @@ internal sealed class TreeEnum(SchemaEditor schemaEditor)
 			{
 				EnumValueName captured = x;
 
-				if (ImGui.Selectable($"Rename {captured}"))
+				bool rename = ImGui.Selectable($"Rename {captured}");
+				ImGuiProbes.MarkItem($"Rename{captured}");
+				if (rename)
 				{
 					schemaEditor.PromptRename("enum value", captured,
 						newName => schemaEnum.TryRenameValue(captured, newName.As<EnumValueName>()));
 				}
 
-				if (ImGui.Selectable($"Delete {captured}"))
+				bool delete = ImGui.Selectable($"Delete {captured}");
+				ImGuiProbes.MarkItem($"Delete{captured}");
+				if (delete)
 				{
 					schemaEditor.Execute(new DelegateCommand(
 						$"Delete Enum Value '{captured}'",


### PR DESCRIPTION
Closes #128.

## What was left

The harness and `SchemaEditor.Test` already existed, and the Sonar coverage exclusion was already narrowed to `SchemaEditor/Program.cs`. What was still missing was the second acceptance item: the parts of the editor that only a click can start had no test, because none of those controls had a name a test could address. Editor line coverage sat at **73.5%**, under the 80% SonarCloud asks of new code, and the gap was exactly the interactive code the issue lists — `SchemaEditor.Files`' menu paths and its save-through-the-browser sequence, and `SchemaEditor.Diagnostics`' panel.

## What this adds

Marking is how this codebase makes a control addressable (`ImGuiProbes.MarkItem`, free when no probe is installed), so the controls that were missing it now have it: menu headers and items, every `EditField` (each is a hidden `##` label, so there was no text to find it by), the class / array-key / language pickers, the member type button and description arrow, Browse and Generate, the diagnostics rows, and the enum value context menu.

New suites, all driven the way a user drives the editor — the menu is opened and the item clicked, the field is typed into and left, the picker is opened and an option chosen:

- **`MenuTests`** — File and Edit, including the enabling rules that live only in the menu (Save with no document, Open Externally with no path, Undo with nothing to undo), the recent-files menu and opening from it.
- **`ShortcutTests`** — Ctrl+N/O/S/Shift+S/Z/Shift+Z/Y, that Save As is recognised before Save, and that a shortcut does not fire while a field is being typed into.
- **`DiagnosticsPanelTests`** — what the panel lists, that errors are listed above warnings, and that a row selects the element its issue is about.
- **`ElementPanelTests`** — renaming from a panel (including a collision being refused with nothing left on the undo stack), descriptions, the data source's class picker, the member type picker, an array's container and key.
- **`CodeGeneratorPanelTests`** — language, namespace, output path, Browse, and Generate: refused until the schema is saved, refused with a reason when the schema has errors, and writing its output when it can.
- **`FileBrowserTests`** — saving a document with no path through the browser, and the continuation that whatever the save was guarding waits for.
- **`SchemaFileTests`** — the load and save failures, and what each is reported as.

## Two bugs this turned up

- **Open Externally was never disabled.** It passed its flag to the two-argument `ImGui.MenuItem` overload, which takes it as the item's *checked* state rather than as whether the item is enabled. The item was drawn with a tick beside it once the schema had a path, and stayed clickable while it had none — handing the shell an empty path, which failed into an error popup.
- **Folded-open state was read off the singleton.** `ToggleVisibility` and `IsVisible` reached for `SchemaEditor.Instance` rather than the editor drawing the row. The application has one editor so it worked, but a suite has one per test, and a row left open by one test came back open in the next. They are instance members now, and `ButtonTree` takes the editor it draws for.

## Notes

`ShowDiagnosticsPanel` is internal so a test can draw it. The tab bar hosting it comes from a widget library that neither records its tabs for a probe nor takes a selection from outside, so there is no tab to click; it is driven through `WidgetHarness` the way the class graph already is.

## Result

182 tests, up from 100, all passing. Editor line coverage **73.5% → 92.3%**. What is left uncovered is the entry point (already excluded), the shell handoff inside `OpenExternally`, and `ConfirmExit`, whose `ImGuiApp.Stop` refuses to run outside a real application loop.

`dotnet build` is clean with this repo's warnings-as-errors analyzers, and `Schema.Test` still passes (304 tests on net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw1CwfGXb6yK6gLdnZYYZK


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw1CwfGXb6yK6gLdnZYYZK)_