### PR TITLE
Take the assertions SonarCloud's analyzer asked for

### DIFF
--- a/SchemaEditor.Test/DiagnosticsPanelTests.cs
+++ b/SchemaEditor.Test/DiagnosticsPanelTests.cs
@@ -79,7 +79,7 @@ public sealed class DiagnosticsPanelTests
 		harness.App.Step(2);
 
 		Assert.IsNull(harness.Editor.CurrentSchema, "This test is about the panel with no document behind it.");
-		Assert.AreEqual(0, ListedIssues.Length);
+		Assert.IsEmpty(ListedIssues);
 	}
 
 	[TestMethod]
@@ -90,8 +90,8 @@ public sealed class DiagnosticsPanelTests
 		harness.Editor.CurrentSchema = schema;
 		Validate();
 
-		Assert.AreEqual(0, harness.Editor.Diagnostics.Count, "This schema was supposed to start clean.");
-		Assert.AreEqual(0, ListedIssues.Length);
+		Assert.IsEmpty(harness.Editor.Diagnostics, "This schema was supposed to start clean.");
+		Assert.IsEmpty(ListedIssues);
 	}
 
 	[TestMethod]
@@ -100,9 +100,11 @@ public sealed class DiagnosticsPanelTests
 		harness.Editor.CurrentSchema = BuildSchemaWithAWarningAndAnError();
 		Validate();
 
-		CollectionAssert.AreEquivalent(
+		// In any order: the panel sorts its rows by severity, which is what the next test is about.
+		Assert.AreSequenceEqual(
 			harness.Editor.Diagnostics.Select(i => $"{i.Severity}:{i.Path}").Distinct().ToArray(),
-			ListedIssues.Distinct().ToArray());
+			ListedIssues.Distinct().ToArray(),
+			SequenceOrder.InAnyOrder);
 	}
 
 	/// <summary>
@@ -120,7 +122,7 @@ public sealed class DiagnosticsPanelTests
 		Rectangle warning = harness.App.Probe.Rect("diagnostic/Warning:User.Untyped")
 			?? throw new AssertFailedException("The member's warning was not listed.");
 
-		Assert.IsTrue(error.MinY < warning.MinY, "The warning was listed above the error.");
+		Assert.IsLessThan(warning.MinY, error.MinY, "The warning was listed above the error.");
 	}
 
 	/// <summary>

--- a/SchemaEditor.Test/ElementPanelTests.cs
+++ b/SchemaEditor.Test/ElementPanelTests.cs
@@ -78,7 +78,7 @@ public sealed class ElementPanelTests
 		harness.App.Step(3);
 
 		Assert.AreEqual("User", user.Name.ToString());
-		Assert.IsTrue(harness.App.Probe.Matches("prompt/OK").Count > 0, "The collision was not reported.");
+		Assert.IsNotEmpty(harness.App.Probe.Matches("prompt/OK"), "The collision was not reported.");
 		Assert.IsFalse(harness.Editor.UndoRedo.CanUndo, "A rename that was refused left an undo entry behind.");
 	}
 
@@ -288,8 +288,9 @@ public sealed class ElementPanelTests
 		harness.Editor.EditClass(user);
 		harness.App.Step(2);
 
-		Assert.IsFalse(
-			harness.App.Probe.KnownNames.Any(name => name.Contains("field/MemberDescription", StringComparison.Ordinal)),
+		Assert.DoesNotContain(
+			name => name.Contains("field/MemberDescription", StringComparison.Ordinal),
+			harness.App.Probe.KnownNames,
 			"The description editor was drawn before the row was opened.");
 	}
 
@@ -302,7 +303,7 @@ public sealed class ElementPanelTests
 
 		harness.Click("memberId/ToggleDescription");
 
-		Assert.IsTrue(harness.App.Probe.Matches("field/MemberDescriptionUser.Id").Count > 0, "The description editor was not drawn.");
+		Assert.IsNotEmpty(harness.App.Probe.Matches("field/MemberDescriptionUser.Id"), "The description editor was not drawn.");
 	}
 
 	/// <summary>

--- a/SchemaEditor.Test/TreeContextMenuTests.cs
+++ b/SchemaEditor.Test/TreeContextMenuTests.cs
@@ -240,8 +240,8 @@ public sealed class TreeContextMenuTests
 		harness.TypeInto("input/field", "Crimson");
 		harness.Click("input/ok");
 
-		Assert.IsTrue(colour.Values.Any(v => v.ToString() == "Crimson"));
-		Assert.IsFalse(colour.Values.Any(v => v.ToString() == "Red"));
+		Assert.Contains(v => v.ToString() == "Crimson", colour.Values);
+		Assert.DoesNotContain(v => v.ToString() == "Red", colour.Values);
 	}
 
 	[TestMethod]
@@ -254,7 +254,7 @@ public sealed class TreeContextMenuTests
 		ChooseFromContextMenu("BtnRed", "DeleteRed");
 
 		string[] remaining = [.. colour.Values.Select(v => v.ToString())];
-		Assert.AreEqual(1, remaining.Length, $"Values were [{string.Join(", ", remaining)}].");
+		Assert.HasCount(1, remaining, $"Values were [{string.Join(", ", remaining)}].");
 		Assert.AreEqual("Green", remaining[0]);
 	}
 
@@ -267,7 +267,7 @@ public sealed class TreeContextMenuTests
 		ChooseFromContextMenu("BtnRed", "DeleteRed");
 		harness.Editor.UndoRedo.Undo();
 
-		Assert.IsTrue(colour.Values.Any(v => v.ToString() == "Red"));
+		Assert.Contains(v => v.ToString() == "Red", colour.Values);
 	}
 
 	[TestMethod]

--- a/SchemaEditor.Test/TreeEditingTests.cs
+++ b/SchemaEditor.Test/TreeEditingTests.cs
@@ -140,7 +140,7 @@ public sealed class TreeEditingTests
 
 		AddNamed("NewEnum", "Colour");
 
-		Assert.AreEqual(1, schema.Enums.Count(e => e.Name.ToString() == "Colour"));
+		Assert.ContainsSingle(e => e.Name.ToString() == "Colour", schema.Enums);
 	}
 
 	[TestMethod]
@@ -151,7 +151,7 @@ public sealed class TreeEditingTests
 
 		AddNamed("NewValue", "Red");
 
-		Assert.AreEqual(1, colour.Values.Count(v => v.ToString() == "Red"));
+		Assert.ContainsSingle(v => v.ToString() == "Red", colour.Values);
 	}
 
 	[TestMethod]
@@ -162,7 +162,7 @@ public sealed class TreeEditingTests
 
 		AddNamed("NewDataSource", "Users");
 
-		Assert.AreEqual(1, schema.DataSources.Count(d => d.Name.ToString() == "Users"));
+		Assert.ContainsSingle(d => d.Name.ToString() == "Users", schema.DataSources);
 	}
 
 	[TestMethod]
@@ -173,7 +173,7 @@ public sealed class TreeEditingTests
 
 		AddNamed("NewCodeGenerator", "CSharp");
 
-		Assert.AreEqual(1, schema.CodeGenerators.Count(g => g.Name.ToString() == "CSharp"));
+		Assert.ContainsSingle(g => g.Name.ToString() == "CSharp", schema.CodeGenerators);
 	}
 
 	[TestMethod]
@@ -186,6 +186,6 @@ public sealed class TreeEditingTests
 
 		AddNamed("User/NewMember", "Age");
 
-		Assert.AreEqual(1, user.Members.Count(m => m.Name.ToString() == "Age"));
+		Assert.ContainsSingle(m => m.Name.ToString() == "Age", user.Members);
 	}
 }

--- a/SchemaEditor/SchemaEditor.Panels.cs
+++ b/SchemaEditor/SchemaEditor.Panels.cs
@@ -26,6 +26,11 @@ public partial class SchemaEditor
 	private static Vector2 DescriptionSize => new(FieldWidth * 3, ImGui.GetTextLineHeight() * 3);
 
 	/// <summary>
+	/// What a picker offers for "point this at nothing", and the name that option is recorded under.
+	/// </summary>
+	private const string NoneOption = "<none>";
+
+	/// <summary>
 	/// Draws a description editor bound to a schema element, committing one undo entry per edit.
 	/// </summary>
 	/// <remarks>
@@ -204,8 +209,8 @@ public partial class SchemaEditor
 			return;
 		}
 
-		bool none = ImGui.Selectable("<none>");
-		ImGuiProbes.MarkItem("class-option", "<none>");
+		bool none = ImGui.Selectable(NoneOption);
+		ImGuiProbes.MarkItem("class-option", NoneOption);
 		if (none)
 		{
 			SetDataSourceClass(dataSource, new ClassName());
@@ -486,7 +491,7 @@ public partial class SchemaEditor
 
 	private void ShowArrayKeySelector(SchemaTypes.Array array, SchemaClass elementClass)
 	{
-		ImGui.Button(string.IsNullOrEmpty(array.Key) ? "<none>" : array.Key, new Vector2(FieldWidth, 0));
+		ImGui.Button(string.IsNullOrEmpty(array.Key) ? NoneOption : array.Key, new Vector2(FieldWidth, 0));
 		ImGuiProbes.MarkItem("KeySelector");
 
 		if (!ImGui.BeginPopupContextItem("##Key", ImGuiPopupFlags.MouseButtonLeft))
@@ -494,8 +499,8 @@ public partial class SchemaEditor
 			return;
 		}
 
-		bool none = ImGui.Selectable("<none>");
-		ImGuiProbes.MarkItem("key-option", "<none>");
+		bool none = ImGui.Selectable(NoneOption);
+		ImGuiProbes.MarkItem("key-option", NoneOption);
 		if (none)
 		{
 			SetArrayKey(array, new MemberName());


### PR DESCRIPTION
Follow-up to #148, which merged before this landed on it. The analysis of that PR passed its quality gate but raised nineteen issues; this clears seventeen of them, and one of the remaining two.

## The assertions

Seventeen are MSTest suggesting a more specific assertion than the one written, all in the suites #148 added:

| Was | Now |
| --- | --- |
| `Assert.AreEqual(0, x.Count)` | `Assert.IsEmpty(x)` |
| `Assert.AreEqual(1, x.Length)` | `Assert.HasCount(1, x)` |
| `Assert.AreEqual(1, x.Count(pred))` | `Assert.ContainsSingle(pred, x)` |
| `Assert.IsTrue(x.Any(pred))` | `Assert.Contains(pred, x)` |
| `Assert.IsFalse(x.Any(pred))` | `Assert.DoesNotContain(pred, x)` |
| `Assert.IsTrue(x.Count > 0)` | `Assert.IsNotEmpty(x)` |
| `Assert.IsTrue(a < b)` | `Assert.IsLessThan(b, a)` |

Each says on failure what was actually in the collection, where the general form only says that a bool was false.

The one equivalence check keeps its meaning rather than taking the suggested form as offered: `Assert.AreSequenceEqual` compares in order by default, and the order the diagnostics panel draws its rows in is exactly what the *next* test is about — so it is asked for `SequenceOrder.InAnyOrder`, which is what `CollectionAssert.AreEquivalent` meant. Taking the swap literally would have made `EveryIssueGetsARow` duplicate `ErrorsAreListedBeforeWarnings` and fail.

## The other two

- **`S1192`, the duplicated `"<none>"` literal** — fixed. It crossed the analyzer's threshold when the class and array-key pickers had their options marked in #148, so it is that change's to clean up; it is a constant now.
- **`S3776`, `ButtonTree.ShowTreeItem`'s cognitive complexity (30 vs. 15)** — deliberately left alone. The complexity predates #148, which only threaded the editor through the signature; Sonar counts the method as new code because that line changed. Reducing it means restructuring the drawing of every tree row, which is not this change's to do — worth its own issue if it is wanted.

## Verification

`dotnet build` clean under the repo's warnings-as-errors analyzers, and the editor suite passes 182/182 on this base. `ErrorsAreListedBeforeWarnings` passing is what confirms `IsLessThan`'s argument order is the intended direction — had the bound and the value been swapped, that test would fail rather than silently assert the opposite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pw1CwfGXb6yK6gLdnZYYZK


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pw1CwfGXb6yK6gLdnZYYZK)_