### PR TITLE
Semantic member metadata, and the editor controls that set it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,17 @@ Example: `"User".As<ClassName>()`
 
 Schema elements maintain parent references via `AssociateWith()` methods. After deserialization, `Schema.Reassociate()` re-establishes these relationships.
 
+### Member metadata
+
+A member carries six optional properties beside its type - `Unit`, `Range`, `DefaultValue`,
+`Interpolation`, `Network` and `Editor` - modelled in `Schema/Models/Metadata/` and validated
+together in `Schema/Models/Schema.Validation.cs`, since most of them are only wrong in combination.
+Units are not modelled here: a member stores the text and `UnitRegistry` resolves it against
+`ktsu.Semantics.Quantities`, reflecting over that assembly rather than keeping a list that would
+fall behind it. Two symbols there are ambiguous (`g`, `rad`), so resolution refuses an ambiguous
+symbol and `UnitRegistry.PreferredText` is what a picker writes: the symbol when it identifies one
+unit, the name when it does not. `docs/schema-format.md` documents the file's side of all of this.
+
 ### Key Files
 
 - `Schema/Contracts/` - The `ISchema` abstraction seam implemented by the models
@@ -81,6 +92,8 @@ Schema elements maintain parent references via `AssociateWith()` methods. After 
 - `Schema/Models/Types/BaseType.cs` - Abstract base with `[JsonDerivedType]` attributes for polymorphic serialization
 - `Schema/Models/SchemaClass.cs` - Class definitions containing `SchemaMember` collections
 - `SchemaEditor/SchemaEditor.cs` - Main editor application using `ktsu.ImGui.App`
+- `SchemaEditor/MemberGridPanel.cs` - The grid of member rows: add, reorder, retype, remove, and the two folds each row opens
+- `SchemaEditor/MemberSemanticsPanel.cs` - The metadata behind a member's fold, and the only place that decides what a picker writes for a unit
 - `SchemaEditor/EditorHost.cs` - Builds the `ImGuiAppConfig`; `CreateConfig` is what the tests drive too
 - `SchemaEditor/EditorTheme.cs` - The ktsu.ThemeProvider theme, and the one definition of how a validation issue is coloured
 - `SchemaEditor/Program.cs` - The entry point, and the only file excluded from coverage measurement
@@ -107,6 +120,7 @@ own delegate does.
 ## Dependencies
 
 - **ktsu.Semantics.Strings/Paths** - Type-safe string and path wrappers
+- **ktsu.Semantics.Quantities** - The units a member's values can be measured in
 - **ktsu.ImGui.App/Widgets/Popups** - ImGui application framework (editor only)
 - **ktsu.AppDataStorage** - Persistent settings storage (editor only)
 - **Polyfill** - .NET compatibility shims for multi-targeting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,11 @@ fall behind it. Two symbols there are ambiguous (`g`, `rad`), so resolution refu
 symbol and `UnitRegistry.PreferredText` is what a picker writes: the symbol when it identifies one
 unit, the name when it does not. `docs/schema-format.md` documents the file's side of all of this.
 
+Generated C# carries the metadata as attributes from `ktsu.Schema.Runtime`, and `ClrTypeImporter`
+reads them back, because none of it is expressible in a CLR type. The two sides are inverses and
+the generate-compile-reimport round-trip test fails if either changes alone. A default is emitted
+as the property initialiser as well, so a generated instance starts at it.
+
 ### Key Files
 
 - `Schema/Contracts/` - The `ISchema` abstraction seam implemented by the models
@@ -91,6 +96,8 @@ unit, the name when it does not. `docs/schema-format.md` documents the file's si
 - `Schema/Models/SchemaChildSet.cs` - Order-preserving, name-unique view owning the uniqueness rule
 - `Schema/Models/Types/BaseType.cs` - Abstract base with `[JsonDerivedType]` attributes for polymorphic serialization
 - `Schema/Models/SchemaClass.cs` - Class definitions containing `SchemaMember` collections
+- `Schema/Models/ClrTypeImporter.cs` - Reads a .NET type into a schema; the exact inverse of the C# generator
+- `Schema/Runtime/SchemaMetadataAttributes.cs` - What generated code carries that its C# types cannot say
 - `SchemaEditor/SchemaEditor.cs` - Main editor application using `ktsu.ImGui.App`
 - `SchemaEditor/MemberGridPanel.cs` - The grid of member rows: add, reorder, retype, remove, and the two folds each row opens
 - `SchemaEditor/MemberSemanticsPanel.cs` - The metadata behind a member's fold, and the only place that decides what a picker writes for a unit

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="ktsu.Keybinding.Core" Version="1.0.44" />
     <PackageVersion Include="ktsu.UndoRedo.Core" Version="1.0.19" />
     <PackageVersion Include="ktsu.RoundTripStringJsonConverter" Version="1.0.55" />
+    <PackageVersion Include="ktsu.Semantics.Quantities" Version="3.3.0" />
     <PackageVersion Include="ktsu.Semantics.Strings" Version="3.3.0" />
     <PackageVersion Include="ktsu.Semantics.Paths" Version="3.3.0" />
     <PackageVersion Include="ktsu.ImGui.App" Version="3.26.1" />

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ dotnet run --project SchemaEditor
 - Tree view for navigating classes, enums, data sources, and code generators
 - Property panels for editing members and types
 - Type selection dialogs
+- A fold behind every member row for its semantic metadata: unit, range, default value,
+  interpolation, network encoding and editor hint
+- A unit picker over every unit in `ktsu.Semantics.Quantities`, searchable by name or symbol
 - Create, open, and save schema files
 - Resizable split-panel layout with persistent settings
 

--- a/Schema.Test/CodeGenerationRoundTripTests.cs
+++ b/Schema.Test/CodeGenerationRoundTripTests.cs
@@ -124,7 +124,7 @@ public class CodeGenerationRoundTripTests
 
 		Assert.AreEqual(1.5f, user.GetProperty("Ratio")!.GetValue(instance));
 		Assert.AreEqual(3, user.GetProperty("Count")!.GetValue(instance));
-		Assert.AreEqual(true, user.GetProperty("Flag")!.GetValue(instance));
+		Assert.IsTrue((bool)user.GetProperty("Flag")!.GetValue(instance)!);
 		Assert.AreEqual("anonymous", user.GetProperty("Name")!.GetValue(instance));
 		Assert.AreEqual("Member", user.GetProperty("Role")!.GetValue(instance)!.ToString());
 	}

--- a/Schema.Test/CodeGenerationRoundTripTests.cs
+++ b/Schema.Test/CodeGenerationRoundTripTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 
 using ktsu.Schema.Generation;
 using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Names;
 using ktsu.Semantics.Strings;
 
@@ -77,6 +78,75 @@ public class CodeGenerationRoundTripTests
 				actualMember.Type,
 				$"'{className}.{expectedMember.Name}' came back as '{actualMember.Type.DisplayName}' " +
 				$"instead of '{expectedMember.Type.DisplayName}'.");
+
+			AssertMetadataMatches(expectedMember, actualMember, $"{className}.{expectedMember.Name}");
 		}
+	}
+
+	/// <summary>
+	/// A member's semantic metadata has to survive the trip too. None of it is expressible in the
+	/// generated property's type, so it survives only as long as the attributes the generator
+	/// writes and the importer reads stay a matched pair - which is the thing this asserts.
+	/// </summary>
+	private static void AssertMetadataMatches(SchemaMember expected, SchemaMember actual, string path)
+	{
+		Assert.AreEqual(expected.Unit?.ToString(), actual.Unit?.ToString(), $"'{path}' lost its unit.");
+		Assert.AreEqual(expected.Interpolation, actual.Interpolation, $"'{path}' lost its interpolation.");
+		Assert.AreEqual(expected.Editor?.ToString(), actual.Editor?.ToString(), $"'{path}' lost its editor hint.");
+
+		Assert.AreEqual(expected.Range?.Minimum, actual.Range?.Minimum, $"'{path}' lost its range minimum.");
+		Assert.AreEqual(expected.Range?.Maximum, actual.Range?.Maximum, $"'{path}' lost its range maximum.");
+		Assert.AreEqual(expected.Range?.Wrap, actual.Range?.Wrap, $"'{path}' lost its wrap flag.");
+
+		Assert.AreEqual(expected.Network?.Quantise, actual.Network?.Quantise, $"'{path}' lost its quantisation step.");
+		Assert.AreEqual(expected.Network?.Delta, actual.Network?.Delta, $"'{path}' lost its delta flag.");
+
+		// Compared by type as well as by text, since a NumberDefault of 1 and a TextDefault of "1"
+		// print the same and mean different things.
+		Assert.AreEqual(expected.DefaultValue?.GetType(), actual.DefaultValue?.GetType(), $"'{path}' changed the kind of its default.");
+		Assert.AreEqual(expected.DefaultValue?.ToString(), actual.DefaultValue?.ToString(), $"'{path}' lost its default.");
+	}
+
+	/// <summary>
+	/// The generated type does not merely record its defaults, it starts at them: an attribute a
+	/// consumer has to read is not the same as an instance that is already right.
+	/// </summary>
+	[TestMethod]
+	public void TestGeneratedPropertiesStartAtTheirDefaults()
+	{
+		Schema schema = CodeGenerationTests.CreateFullSchema();
+		SchemaGenerationResult result = SchemaGenerator.Generate(schema, CodeGenerationTests.ConfigureGenerator(schema));
+		Assert.IsTrue(result.IsSuccess, result.Message);
+
+		Assembly assembly = GeneratedSourceCompiler.Compile(result.Files);
+		Type user = assembly.GetType("Generated.User", throwOnError: true)!;
+		object instance = Activator.CreateInstance(user)!;
+
+		Assert.AreEqual(1.5f, user.GetProperty("Ratio")!.GetValue(instance));
+		Assert.AreEqual(3, user.GetProperty("Count")!.GetValue(instance));
+		Assert.AreEqual(true, user.GetProperty("Flag")!.GetValue(instance));
+		Assert.AreEqual("anonymous", user.GetProperty("Name")!.GetValue(instance));
+		Assert.AreEqual("Member", user.GetProperty("Role")!.GetValue(instance)!.ToString());
+	}
+
+	/// <summary>
+	/// A default of the wrong kind for its member cannot reach the generator through
+	/// <see cref="SchemaGenerator"/>, which refuses an invalid schema - but the generator is public
+	/// and can be called directly. It falls back to the type's own initialiser rather than emitting
+	/// source that does not compile.
+	/// </summary>
+	[TestMethod]
+	public void TestAMismatchedDefaultDoesNotBreakTheGeneratedSource()
+	{
+		Schema schema = CodeGenerationTests.CreateFullSchema();
+		schema.GetClass("User".As<ClassName>())!.GetMember("Name".As<MemberName>())!.DefaultValue = new NumberDefault { Value = 4.0 };
+
+		IReadOnlyDictionary<string, string> files =
+			new CSharpCodeGenerator().Generate(schema, CodeGenerationTests.ConfigureGenerator(schema));
+
+		Assembly assembly = GeneratedSourceCompiler.Compile(files);
+		object instance = Activator.CreateInstance(assembly.GetType("Generated.User", throwOnError: true)!)!;
+
+		Assert.AreEqual(string.Empty, assembly.GetType("Generated.User")!.GetProperty("Name")!.GetValue(instance));
 	}
 }

--- a/Schema.Test/CodeGenerationTests.cs
+++ b/Schema.Test/CodeGenerationTests.cs
@@ -4,6 +4,7 @@ namespace ktsu.Schema.Tests;
 
 using ktsu.Schema.Generation;
 using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Names;
 using ktsu.Semantics.Paths;
 using ktsu.Semantics.Strings;
@@ -31,7 +32,8 @@ public class CodeGenerationTests
 	}
 
 	/// <summary>
-	/// A schema exercising every built-in type and both container kinds.
+	/// A schema exercising every built-in type, both container kinds, and every kind of member
+	/// metadata.
 	/// </summary>
 	internal static Schema CreateFullSchema()
 	{
@@ -74,6 +76,24 @@ public class CodeGenerationTests
 			Container = ContainerName.Map,
 			Key = "Id".As<MemberName>(),
 		});
+
+		// The metadata, spread across the member kinds that can carry each piece so the round trip
+		// sees a unit on a vector as well as on a scalar, and a default of every kind.
+		SchemaMember ratio = user.GetMember("Ratio".As<MemberName>())!;
+		ratio.Unit = "m/s".As<UnitSymbol>();
+		ratio.Range = new MemberRange { Minimum = 0.0, Maximum = 6.2831853, Wrap = true };
+		ratio.DefaultValue = new NumberDefault { Value = 1.5 };
+		ratio.Editor = "dial".As<EditorHint>();
+
+		SchemaMember position = user.GetMember("Position3".As<MemberName>())!;
+		position.Unit = "Radian".As<UnitSymbol>();
+		position.Interpolation = Interpolation.Spherical;
+		position.Network = new MemberNetwork { Quantise = 0.01, Delta = true };
+
+		user.GetMember("Count".As<MemberName>())!.DefaultValue = new NumberDefault { Value = 3.0 };
+		user.GetMember("Flag".As<MemberName>())!.DefaultValue = new BooleanDefault { Value = true };
+		user.GetMember("Name".As<MemberName>())!.DefaultValue = new TextDefault { Value = "anonymous" };
+		user.GetMember("Role".As<MemberName>())!.DefaultValue = new TextDefault { Value = "Member" };
 
 		return schema;
 	}

--- a/Schema.Test/MemberMetadataTests.cs
+++ b/Schema.Test/MemberMetadataTests.cs
@@ -179,6 +179,21 @@ public class MemberMetadataTests
 		AssertMentions(Errors(schema), "wrap into");
 	}
 
+	/// <summary>
+	/// A backwards range has no width to ask about, so it is one mistake and one message.
+	/// </summary>
+	[TestMethod]
+	public void ABackwardsWrappingRangeIsReportedOnce()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 10.0, Maximum = 1.0, Wrap = true };
+
+		Collection<SchemaValidationIssue> errors = Errors(schema);
+
+		Assert.AreEqual(1, errors.Count, string.Join(" | ", errors.Select(issue => issue.Message)));
+		AssertMentions(errors, "no value satisfies");
+	}
+
 	// ---------------------------------------------------------------- defaults
 
 	[TestMethod]
@@ -208,6 +223,18 @@ public class MemberMetadataTests
 	{
 		SchemaMember member = MemberWith(new SchemaTypes.Int(), out Schema schema);
 		member.DefaultValue = new NumberDefault { Value = 1.5 };
+
+		AssertMentions(Errors(schema), "not a whole number");
+	}
+
+	/// <summary>
+	/// An infinity is not a whole number, and cannot be narrowed to one.
+	/// </summary>
+	[TestMethod]
+	public void AnInfiniteDefaultOnAnIntegralMemberIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Int(), out Schema schema);
+		member.DefaultValue = new NumberDefault { Value = double.PositiveInfinity };
 
 		AssertMentions(Errors(schema), "not a whole number");
 	}

--- a/Schema.Test/MemberMetadataTests.cs
+++ b/Schema.Test/MemberMetadataTests.cs
@@ -1,0 +1,354 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Tests;
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Quantities;
+using ktsu.Semantics.Strings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SchemaTypes = Models.Types;
+
+/// <summary>
+/// Covers the semantic metadata a member can carry: its unit, range, default, interpolation
+/// and network encoding.
+/// </summary>
+[TestClass]
+public class MemberMetadataTests
+{
+	private static SchemaMember MemberWith(SchemaTypes.BaseType type, out Schema schema)
+	{
+		schema = new Schema();
+		SchemaClass owner = schema.AddClass("Body".As<ClassName>())!;
+		SchemaMember member = owner.AddMember("Value".As<MemberName>())!;
+		member.SetType(type);
+		return member;
+	}
+
+	private static Collection<SchemaValidationIssue> Errors(Schema schema) =>
+		new([.. schema.Validate().Where(issue => issue.Severity == SchemaValidationSeverity.Error)]);
+
+	private static void AssertMentions(Collection<SchemaValidationIssue> issues, string fragment)
+	{
+		Assert.IsTrue(
+			issues.Any(issue => issue.Message.Contains(fragment, System.StringComparison.OrdinalIgnoreCase)),
+			$"expected an issue mentioning '{fragment}', got: {string.Join(" | ", issues.Select(i => i.Message))}");
+	}
+
+	// ------------------------------------------------------------------- units
+
+	[TestMethod]
+	public void ASymbolResolvesToItsUnit()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out _);
+		member.Unit = "m/s".As<UnitSymbol>();
+
+		Assert.IsTrue(member.TryResolveUnit(out IUnit? unit, out string error), error);
+		Assert.AreEqual("MeterPerSecond", unit!.Name);
+		Assert.AreEqual(1, unit.Dimension.DimensionalFormula["length"]);
+		Assert.AreEqual(-1, unit.Dimension.DimensionalFormula["time"]);
+	}
+
+	[TestMethod]
+	public void AUnitNameResolvesToo()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out _);
+		member.Unit = "MeterPerSecond".As<UnitSymbol>();
+
+		Assert.IsTrue(member.TryResolveUnit(out IUnit? unit, out _));
+		Assert.AreEqual("MeterPerSecond", unit!.Name);
+	}
+
+	[TestMethod]
+	public void AnAmbiguousSymbolIsRefusedAndNamesTheCandidates()
+	{
+		// 'rad' is the symbol of both Radian and Rad, which are different dimensions
+		// entirely -- an angle and an absorbed radiation dose. Picking one silently would
+		// be the worst available outcome.
+		Assert.IsFalse(UnitRegistry.TryResolve("rad", out IUnit? unit, out string error));
+		Assert.IsNull(unit);
+		StringAssert.Contains(error, "Radian");
+		StringAssert.Contains(error, "Rad");
+		StringAssert.Contains(error, "name");
+	}
+
+	[TestMethod]
+	public void TheNameEscapesTheAmbiguousSymbol()
+	{
+		Assert.IsTrue(UnitRegistry.TryResolve("Radian", out IUnit? radian, out _));
+		Assert.IsTrue(UnitRegistry.TryResolve("Rad", out IUnit? rad, out _));
+		Assert.AreNotEqual(radian!.Dimension.Name, rad!.Dimension.Name);
+	}
+
+	[TestMethod]
+	public void AnUnknownUnitIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Unit = "furlong".As<UnitSymbol>();
+
+		AssertMentions(Errors(schema), "not a known unit");
+	}
+
+	[TestMethod]
+	public void AUnitOnSomethingThatMeasuresNothingIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.String(), out Schema schema);
+		member.Unit = "m".As<UnitSymbol>();
+
+		AssertMentions(Errors(schema), "meaningless");
+	}
+
+	[TestMethod]
+	public void AVectorMayCarryAUnit()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Vector3(), out Schema schema);
+		member.Unit = "m/s".As<UnitSymbol>();
+
+		Assert.AreEqual(0, Errors(schema).Count);
+	}
+
+	[TestMethod]
+	public void TheRegistryIsNotEmpty()
+	{
+		// Guards the reflection that builds it: a registry that silently found nothing
+		// would make every unit unresolvable and every unit test above fail confusingly.
+		Assert.IsTrue(UnitRegistry.All.Count > 100, $"registry holds only {UnitRegistry.All.Count} units");
+	}
+
+	// ------------------------------------------------------------------ ranges
+
+	[TestMethod]
+	public void ABackwardsRangeIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 10.0, Maximum = 1.0 };
+
+		AssertMentions(Errors(schema), "no value satisfies");
+	}
+
+	[TestMethod]
+	public void ARangeOnAStringIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.String(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 0.0, Maximum = 1.0 };
+
+		AssertMentions(Errors(schema), "meaningless");
+	}
+
+	[TestMethod]
+	public void AZeroWidthWrappingRangeIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 1.0, Maximum = 1.0, Wrap = true };
+
+		AssertMentions(Errors(schema), "wrap into");
+	}
+
+	// ---------------------------------------------------------------- defaults
+
+	[TestMethod]
+	public void ADefaultOutsideItsRangeIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 0.0, Maximum = 1.0 };
+		member.DefaultValue = new NumberDefault { Value = 2.0 };
+
+		AssertMentions(Errors(schema), "outside the member's own range");
+	}
+
+	[TestMethod]
+	public void ADefaultOutsideAWrappingRangeIsFine()
+	{
+		// A wrapping range is a period, not a bound: 7 radians is un-normalised rather
+		// than wrong. This is the case a range-only reading gets backwards.
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 0.0, Maximum = 6.2831853, Wrap = true };
+		member.DefaultValue = new NumberDefault { Value = 7.0 };
+
+		Assert.AreEqual(0, Errors(schema).Count);
+	}
+
+	[TestMethod]
+	public void AFractionalDefaultOnAnIntegralMemberIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Int(), out Schema schema);
+		member.DefaultValue = new NumberDefault { Value = 1.5 };
+
+		AssertMentions(Errors(schema), "not a whole number");
+	}
+
+	[TestMethod]
+	public void ADefaultOfTheWrongKindIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.DefaultValue = new BooleanDefault { Value = true };
+
+		AssertMentions(Errors(schema), "does not fit");
+	}
+
+	[TestMethod]
+	public void AnEnumDefaultMustNameAValueOfThatEnum()
+	{
+		Schema schema = new();
+		SchemaEnum kind = schema.AddEnum("Kind".As<EnumName>())!;
+		kind.TryAddValue("Sphere".As<EnumValueName>());
+		kind.TryAddValue("Box".As<EnumValueName>());
+
+		SchemaClass owner = schema.AddClass("Collider".As<ClassName>())!;
+		SchemaMember member = owner.AddMember("Kind".As<MemberName>())!;
+		member.SetType(new SchemaTypes.Enum { EnumName = "Kind".As<EnumName>() });
+
+		member.DefaultValue = new TextDefault { Value = "Sphere" };
+		Assert.AreEqual(0, Errors(schema).Count);
+
+		member.DefaultValue = new TextDefault { Value = "Capsule" };
+		AssertMentions(Errors(schema), "not a value of enum");
+	}
+
+	// ----------------------------------------------------------- interpolation
+
+	[TestMethod]
+	public void AnEnumCannotBeInterpolated()
+	{
+		Schema schema = new();
+		SchemaEnum kind = schema.AddEnum("Kind".As<EnumName>())!;
+		kind.TryAddValue("Sphere".As<EnumValueName>());
+
+		SchemaClass owner = schema.AddClass("Collider".As<ClassName>())!;
+		SchemaMember member = owner.AddMember("Kind".As<MemberName>())!;
+		member.SetType(new SchemaTypes.Enum { EnumName = "Kind".As<EnumName>() });
+		member.Interpolation = Interpolation.Linear;
+
+		AssertMentions(Errors(schema), "no meaningful value between two states");
+	}
+
+	[TestMethod]
+	public void AVectorMayBeInterpolated()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Vector3(), out Schema schema);
+		member.Interpolation = Interpolation.Linear;
+
+		Assert.AreEqual(0, Errors(schema).Count);
+	}
+
+	// --------------------------------------------------------------- networking
+
+	[TestMethod]
+	public void ANegativeQuantisationStepIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Network = new MemberNetwork { Quantise = -0.5 };
+
+		AssertMentions(Errors(schema), "must not be negative");
+	}
+
+	[TestMethod]
+	public void QuantisingAStringIsAnError()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.String(), out Schema schema);
+		member.Network = new MemberNetwork { Quantise = 0.5 };
+
+		AssertMentions(Errors(schema), "no numeric value to quantise");
+	}
+
+	[TestMethod]
+	public void AStepWiderThanTheRangeIsAWarning()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Float(), out Schema schema);
+		member.Range = new MemberRange { Minimum = 0.0, Maximum = 1.0 };
+		member.Network = new MemberNetwork { Quantise = 10.0 };
+
+		Collection<SchemaValidationIssue> issues = schema.Validate();
+		Assert.AreEqual(0, Errors(schema).Count, "a coarse step is suspicious, not invalid");
+		Assert.IsTrue(issues.Any(issue =>
+			issue.Severity == SchemaValidationSeverity.Warning &&
+			issue.Message.Contains("wider than", System.StringComparison.Ordinal)));
+	}
+
+	// ------------------------------------------------------------- round trip
+
+	[TestMethod]
+	public void MetadataSurvivesASaveAndLoad()
+	{
+		// The metadata is polymorphic, and polymorphic JSON is exactly where a private
+		// setter or a missing discriminator silently drops data on load rather than
+		// failing. So the round trip is asserted rather than assumed.
+		Schema schema = new();
+		SchemaClass owner = schema.AddClass("RigidBody".As<ClassName>())!;
+
+		SchemaMember velocity = owner.AddMember("Velocity".As<MemberName>())!;
+		velocity.SetType(new SchemaTypes.Vector3());
+		velocity.Unit = "m/s".As<UnitSymbol>();
+		velocity.Interpolation = Interpolation.Linear;
+		velocity.Network = new MemberNetwork { Quantise = 0.01, Delta = true };
+
+		SchemaMember heading = owner.AddMember("Heading".As<MemberName>())!;
+		heading.SetType(new SchemaTypes.Float());
+		heading.Unit = "Radian".As<UnitSymbol>();
+		heading.Range = new MemberRange { Minimum = 0.0, Maximum = 6.2831853, Wrap = true };
+		heading.DefaultValue = new NumberDefault { Value = 0.0 };
+		heading.Editor = "dial".As<EditorHint>();
+
+		string json = SchemaSerializer.Serialize(schema);
+		Assert.IsTrue(SchemaSerializer.TryDeserialize(json, out Schema? loaded), "the schema did not deserialize");
+
+		SchemaClass reloaded = loaded!.Classes.Single();
+		SchemaMember loadedVelocity = reloaded.Members.First(m => m.Name == "Velocity");
+		SchemaMember loadedHeading = reloaded.Members.First(m => m.Name == "Heading");
+
+		Assert.AreEqual("m/s", loadedVelocity.Unit?.ToString());
+		Assert.AreEqual(Interpolation.Linear, loadedVelocity.Interpolation);
+		Assert.AreEqual(0.01, loadedVelocity.Network?.Quantise);
+		Assert.IsTrue(loadedVelocity.Network?.Delta);
+
+		Assert.AreEqual("Radian", loadedHeading.Unit?.ToString());
+		Assert.AreEqual(6.2831853, loadedHeading.Range?.Maximum);
+		Assert.IsTrue(loadedHeading.Range?.Wrap);
+		Assert.AreEqual("dial", loadedHeading.Editor?.ToString());
+
+		// The polymorphic case: a NumberDefault must come back as a NumberDefault, not as
+		// the abstract base or as null.
+		Assert.IsInstanceOfType<NumberDefault>(loadedHeading.DefaultValue);
+		Assert.AreEqual(0.0, ((NumberDefault)loadedHeading.DefaultValue!).Value);
+	}
+
+	[TestMethod]
+	public void TheFileHoldsNoDerivedStateAndNoEnumOrdinals()
+	{
+		// A round trip cannot see either of these: a derived property written to the file
+		// reads back consistently, and an ordinal deserializes to the same value it was
+		// written from. Both are still wrong. A derived property is a second, independently
+		// editable copy of a fact the file already states, and an ordinal means inserting a
+		// mode into the enum silently changes what every existing schema says.
+		Schema schema = new();
+		SchemaClass owner = schema.AddClass("Body".As<ClassName>())!;
+		SchemaMember member = owner.AddMember("Heading".As<MemberName>())!;
+		member.SetType(new SchemaTypes.Float());
+		member.Range = new MemberRange { Minimum = 0.0, Maximum = 1.0 };
+		member.Network = new MemberNetwork { Quantise = 0.25 };
+		member.Interpolation = Interpolation.Spherical;
+
+		string json = SchemaSerializer.Serialize(schema);
+
+		StringAssert.Contains(json, "\"interpolation\": \"Spherical\"");
+		Assert.IsFalse(json.Contains("isWellFormed", System.StringComparison.OrdinalIgnoreCase), json);
+		Assert.IsFalse(json.Contains("isQuantised", System.StringComparison.OrdinalIgnoreCase), json);
+	}
+
+	[TestMethod]
+	public void AMemberWithNoMetadataStaysThatWay()
+	{
+		SchemaMember member = MemberWith(new SchemaTypes.Int(), out Schema schema);
+
+		Assert.IsNull(member.Unit);
+		Assert.IsNull(member.Range);
+		Assert.IsNull(member.DefaultValue);
+		Assert.IsNull(member.Network);
+		Assert.IsNull(member.Editor);
+		Assert.AreEqual(Interpolation.None, member.Interpolation);
+		Assert.AreEqual(0, Errors(schema).Count);
+	}
+}

--- a/Schema.Test/MemberMetadataTests.cs
+++ b/Schema.Test/MemberMetadataTests.cs
@@ -111,6 +111,38 @@ public class MemberMetadataTests
 	}
 
 	[TestMethod]
+	public void TheTextToWriteForAUnitIsItsSymbolUnlessThatIsShared()
+	{
+		// What a picker writes when the user has chosen a unit rather than typed one. The symbol
+		// reads better and is right for all but the shared two, and the point of choosing per unit
+		// is that those two are the only ones that have to be spelled out.
+		Assert.IsTrue(UnitRegistry.TryResolve("MeterPerSecond", out IUnit? metersPerSecond, out _));
+		Assert.AreEqual("m/s", UnitRegistry.PreferredText(metersPerSecond!));
+
+		Assert.IsTrue(UnitRegistry.TryResolve("Radian", out IUnit? radian, out _));
+		Assert.AreEqual("Radian", UnitRegistry.PreferredText(radian!));
+
+		Assert.IsTrue(UnitRegistry.TryResolve("Gram", out IUnit? gram, out _));
+		Assert.AreEqual("Gram", UnitRegistry.PreferredText(gram!));
+	}
+
+	/// <summary>
+	/// The property that matters: whatever text is written for a unit has to name that same unit
+	/// when it is read back. Asserted over the whole registry rather than a sample, since the
+	/// spellings that do not round-trip are exactly the ones nobody thinks to sample.
+	/// </summary>
+	[TestMethod]
+	public void EveryUnitsPreferredTextResolvesBackToIt()
+	{
+		foreach (IUnit unit in UnitRegistry.All)
+		{
+			string text = UnitRegistry.PreferredText(unit);
+			Assert.IsTrue(UnitRegistry.TryResolve(text, out IUnit? resolved, out string error), $"'{text}' for {unit.Name}: {error}");
+			Assert.AreEqual(unit.Name, resolved!.Name, $"'{text}' was written for {unit.Name}");
+		}
+	}
+
+	[TestMethod]
 	public void TheRegistryIsNotEmpty()
 	{
 		// Guards the reflection that builds it: a registry that silently found nothing

--- a/Schema/Contracts/ISchemaMember.cs
+++ b/Schema/Contracts/ISchemaMember.cs
@@ -2,6 +2,7 @@
 
 namespace ktsu.Schema.Contracts;
 
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Names;
 
 /// <summary>
@@ -24,4 +25,34 @@ public interface ISchemaMember : ISchemaClassChild<MemberName>
 	/// </remarks>
 	/// <param name="type">The type to set.</param>
 	public void SetType(ISchemaType type);
+
+	/// <summary>
+	/// Gets the unit this member's values are measured in, or null if it measures nothing.
+	/// </summary>
+	public UnitSymbol? Unit { get; }
+
+	/// <summary>
+	/// Gets the range of values this member may take, or null if it is unbounded.
+	/// </summary>
+	public MemberRange? Range { get; }
+
+	/// <summary>
+	/// Gets the value this member takes when none is supplied, or null if it has no default.
+	/// </summary>
+	public MemberDefault? DefaultValue { get; }
+
+	/// <summary>
+	/// Gets how this member should be encoded when sent over a network, or null for no guidance.
+	/// </summary>
+	public MemberNetwork? Network { get; }
+
+	/// <summary>
+	/// Gets how two states of this member may be blended.
+	/// </summary>
+	public Interpolation Interpolation { get; }
+
+	/// <summary>
+	/// Gets a hint about how an editor should present this member, or null for none.
+	/// </summary>
+	public EditorHint? Editor { get; }
 }

--- a/Schema/Generation/CSharpCodeGenerator.cs
+++ b/Schema/Generation/CSharpCodeGenerator.cs
@@ -2,8 +2,11 @@
 
 namespace ktsu.Schema.Generation;
 
+using System.Globalization;
+
 using ktsu.CodeBlocker;
 using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Names;
 using ktsu.Schema.Models.Types;
 
@@ -86,7 +89,8 @@ public sealed class CSharpCodeGenerator : ISchemaCodeGenerator
 
 				WriteDocComment(code, member.Description);
 				WriteSchemaKeyAttribute(code, member.Type);
-				code.WriteLine($"public {MapType(member.Type)} {member.Name} {{ get; set; }}{InitialiserFor(member.Type)}");
+				WriteMetadataAttributes(code, member);
+				code.WriteLine($"public {MapType(member.Type)} {member.Name} {{ get; set; }}{InitialiserFor(member)}");
 			}
 		}
 
@@ -146,6 +150,85 @@ public sealed class CSharpCodeGenerator : ISchemaCodeGenerator
 			code.WriteLine($"[ktsu.Schema.Runtime.SchemaKey(\"{arrayType.Key}\")]");
 		}
 	}
+
+	/// <summary>
+	/// Records a member's semantic metadata on the generated property.
+	/// </summary>
+	/// <remarks>
+	/// A C# type says what a value is and nothing about what it means, so without these the unit,
+	/// range, default, interpolation and network encoding would be dropped by the reimport the
+	/// round trip is built on - the same problem <see cref="WriteSchemaKeyAttribute"/> solves for
+	/// a keyed map.
+	/// </remarks>
+	private static void WriteMetadataAttributes(CodeBlocker code, SchemaMember member)
+	{
+		if (member.Unit is not null)
+		{
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaUnit({Quote(member.Unit)})]");
+		}
+
+		if (member.Range is MemberRange range)
+		{
+			string wrap = range.Wrap ? ", Wrap = true" : string.Empty;
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaRange({Literal(range.Minimum)}, {Literal(range.Maximum)}{wrap})]");
+		}
+
+		if (DefaultArgument(member.DefaultValue) is string argument)
+		{
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaDefault({argument})]");
+		}
+
+		if (member.Interpolation is not Interpolation.None)
+		{
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaInterpolation(ktsu.Schema.Models.Metadata.Interpolation.{member.Interpolation})]");
+		}
+
+		if (member.Network is MemberNetwork network)
+		{
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaNetwork({Literal(network.Quantise)}, {(network.Delta ? "true" : "false")})]");
+		}
+
+		if (member.Editor is not null)
+		{
+			code.WriteLine($"[ktsu.Schema.Runtime.SchemaEditorHint({Quote(member.Editor)})]");
+		}
+	}
+
+	/// <summary>
+	/// Writes a default as the argument that binds the right <c>SchemaDefault</c> constructor.
+	/// </summary>
+	/// <returns>The argument text, or null when the member has no default.</returns>
+	private static string? DefaultArgument(MemberDefault? value) => value switch
+	{
+		NumberDefault number => Literal(number.Value),
+		BooleanDefault boolean => boolean.Value ? "true" : "false",
+		TextDefault text => Quote(text.Value),
+		_ => null,
+	};
+
+	/// <summary>
+	/// Writes a double as a C# literal of type <see cref="double"/>.
+	/// </summary>
+	/// <remarks>
+	/// The <c>D</c> suffix is what picks the double overload of <c>SchemaDefault</c> rather than
+	/// the one taking a bool or a string, and round-trip formatting is what keeps the value the
+	/// schema holds - a bound written back one bit short is a range that no longer contains what
+	/// it used to. Invariant, because a machine writing a decimal comma would emit source that
+	/// does not compile.
+	/// </remarks>
+	private static string Literal(double value) => value switch
+	{
+		double.PositiveInfinity => "double.PositiveInfinity",
+		double.NegativeInfinity => "double.NegativeInfinity",
+		_ when double.IsNaN(value) => "double.NaN",
+		_ => $"{value.ToString("R", CultureInfo.InvariantCulture)}D",
+	};
+
+	/// <summary>
+	/// Writes text as a C# string literal.
+	/// </summary>
+	private static string Quote(string text) =>
+		$"\"{text.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
 
 	private static string Escape(string text) =>
 		text.Replace("&", "&amp;", StringComparison.Ordinal)
@@ -218,16 +301,42 @@ public sealed class CSharpCodeGenerator : ISchemaCodeGenerator
 	}
 
 	/// <summary>
-	/// Gets the initialiser a property needs to satisfy nullable reference analysis.
+	/// Gets the initialiser a property is given: the member's default when it has one, and
+	/// otherwise whatever nullable reference analysis needs.
 	/// </summary>
-	private static string InitialiserFor(BaseType type) => type switch
+	/// <remarks>
+	/// A default that is only recorded in an attribute is a default in name only - an instance of
+	/// the generated type would still start at zero. The attribute is what lets the default be
+	/// read back; this is what makes it true of the object.
+	/// </remarks>
+	private static string InitialiserFor(SchemaMember member) =>
+		DefaultInitialiserFor(member) ?? member.Type switch
+		{
+			Models.Types.String => " = string.Empty;",
+			Models.Types.Array arrayType => $" = new {MapArray(arrayType)}();",
+			Models.Types.Object objectType => $" = new {objectType.ClassName}();",
+			_ => string.Empty,
+		};
+
+	/// <summary>
+	/// Gets the initialiser for a member's default, or null when it has none that fits.
+	/// </summary>
+	/// <remarks>
+	/// A default of a kind the member cannot hold is a validation error, and generation is refused
+	/// for a schema that has one - so the mismatched cases here are only reachable by calling this
+	/// generator directly on a schema that was never validated. They fall through to the type's
+	/// own initialiser rather than emitting source that does not compile.
+	/// </remarks>
+	private static string? DefaultInitialiserFor(SchemaMember member) => (member.DefaultValue, member.Type) switch
 	{
-		Models.Types.String => " = string.Empty;",
-		Models.Types.Array => $" = new {MapArrayInitialiser(type)}();",
-		Models.Types.Object objectType => $" = new {objectType.ClassName}();",
-		_ => string.Empty,
+		(NumberDefault number, Int) => $" = {(long)number.Value};",
+		(NumberDefault number, Long) => $" = {(long)number.Value}L;",
+		(NumberDefault number, Float) => $" = {number.Value.ToString("R", CultureInfo.InvariantCulture)}f;",
+		(NumberDefault number, Double) => $" = {Literal(number.Value)};",
+		(BooleanDefault boolean, Bool) => $" = {(boolean.Value ? "true" : "false")};",
+		(TextDefault text, Models.Types.String) => $" = {Quote(text.Value)};",
+		(TextDefault text, Models.Types.Enum enumType) => $" = {enumType.EnumName}.{text.Value};",
+		_ => null,
 	};
 
-	private static string MapArrayInitialiser(BaseType type) =>
-		type is Models.Types.Array arrayType ? MapArray(arrayType) : string.Empty;
 }

--- a/Schema/Models/ClrTypeImporter.cs
+++ b/Schema/Models/ClrTypeImporter.cs
@@ -37,44 +37,53 @@ internal static class ClrTypeImporter
 
 		ClassName className = type.Name.As<ClassName>();
 		SchemaClass? schemaClass = schema.AddClass(className);
-		if (schemaClass is not null)
+		if (schemaClass is null)
 		{
-			// Add properties as members
-			foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-			{
-				MemberName memberName = property.Name.As<MemberName>();
-				SchemaMember? member = schemaClass.AddMember(memberName);
-				if (member is not null)
-				{
-					BaseType? schemaType = GetOrCreateSchemaType(schema, property.PropertyType);
-					if (schemaType is not null)
-					{
-						ApplySchemaKey(schemaType, property);
-						member.SetType(schemaType);
-						ApplyMemberMetadata(member, property);
-					}
-				}
-			}
+			return null;
+		}
 
-			// Add fields as members
-			foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
-			{
-				MemberName memberName = field.Name.As<MemberName>();
-				SchemaMember? member = schemaClass.AddMember(memberName);
-				if (member is not null)
-				{
-					BaseType? schemaType = GetOrCreateSchemaType(schema, field.FieldType);
-					if (schemaType is not null)
-					{
-						ApplySchemaKey(schemaType, field);
-						member.SetType(schemaType);
-						ApplyMemberMetadata(member, field);
-					}
-				}
-			}
+		foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			ImportMember(schema, schemaClass, property, property.PropertyType);
+		}
+
+		foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+		{
+			ImportMember(schema, schemaClass, field, field.FieldType);
 		}
 
 		return schemaClass;
+	}
+
+	/// <summary>
+	/// Reads one property or field into a member of the class being imported.
+	/// </summary>
+	/// <remarks>
+	/// A property and a field are read the same way, and the only thing that differs is where the
+	/// type comes from - which is why the caller supplies it rather than this asking which kind of
+	/// member it was handed.
+	/// </remarks>
+	/// <param name="schema">The schema being built, for the types this member refers to.</param>
+	/// <param name="schemaClass">The class the member belongs to.</param>
+	/// <param name="info">The property or field to read, and the attributes on it.</param>
+	/// <param name="memberType">The CLR type of the value it holds.</param>
+	private static void ImportMember(Schema schema, SchemaClass schemaClass, MemberInfo info, Type memberType)
+	{
+		SchemaMember? member = schemaClass.AddMember(info.Name.As<MemberName>());
+		if (member is null)
+		{
+			return;
+		}
+
+		BaseType? schemaType = GetOrCreateSchemaType(schema, memberType);
+		if (schemaType is null)
+		{
+			return;
+		}
+
+		ApplySchemaKey(schemaType, info);
+		member.SetType(schemaType);
+		ApplyMemberMetadata(member, info);
 	}
 
 	private static BaseType? GetOrCreateSchemaType(Schema schema, Type type)

--- a/Schema/Models/ClrTypeImporter.cs
+++ b/Schema/Models/ClrTypeImporter.cs
@@ -1,0 +1,264 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models;
+
+using System.Reflection;
+
+using ktsu.Schema.Models.Metadata;
+using ktsu.Schema.Models.Names;
+using ktsu.Schema.Models.Types;
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// Reads a .NET type into a schema, which is how a schema is built from code rather than from a
+/// file.
+/// </summary>
+/// <remarks>
+/// Its own class rather than part of <see cref="Schema"/>: the mapping it holds is the exact
+/// inverse of what <see cref="Generation.CSharpCodeGenerator"/> emits, including the attributes
+/// carrying everything a CLR type cannot say - a keyed map's key member, and a member's unit,
+/// range, default, interpolation and network encoding. Keeping the two mappings as a matched pair
+/// is what the generate-then-reimport round-trip test checks, and it reads better beside the
+/// generator than buried in the schema's own API.
+/// </remarks>
+internal static class ClrTypeImporter
+{
+	/// <summary>
+	/// Reads a .NET type into a schema as a class, with a member for each of its properties and
+	/// fields.
+	/// </summary>
+	/// <param name="schema">The schema to add the class to.</param>
+	/// <param name="type">The .NET type to read.</param>
+	/// <returns>The added class if successful, null otherwise.</returns>
+	internal static SchemaClass? Import(Schema schema, Type type)
+	{
+		Ensure.NotNull(schema);
+		Ensure.NotNull(type);
+
+		ClassName className = type.Name.As<ClassName>();
+		SchemaClass? schemaClass = schema.AddClass(className);
+		if (schemaClass is not null)
+		{
+			// Add properties as members
+			foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+			{
+				MemberName memberName = property.Name.As<MemberName>();
+				SchemaMember? member = schemaClass.AddMember(memberName);
+				if (member is not null)
+				{
+					BaseType? schemaType = GetOrCreateSchemaType(schema, property.PropertyType);
+					if (schemaType is not null)
+					{
+						ApplySchemaKey(schemaType, property);
+						member.SetType(schemaType);
+						ApplyMemberMetadata(member, property);
+					}
+				}
+			}
+
+			// Add fields as members
+			foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
+			{
+				MemberName memberName = field.Name.As<MemberName>();
+				SchemaMember? member = schemaClass.AddMember(memberName);
+				if (member is not null)
+				{
+					BaseType? schemaType = GetOrCreateSchemaType(schema, field.FieldType);
+					if (schemaType is not null)
+					{
+						ApplySchemaKey(schemaType, field);
+						member.SetType(schemaType);
+						ApplyMemberMetadata(member, field);
+					}
+				}
+			}
+		}
+
+		return schemaClass;
+	}
+
+	private static BaseType? GetOrCreateSchemaType(Schema schema, Type type)
+	{
+		Ensure.NotNull(type);
+
+		type = Nullable.GetUnderlyingType(type) ?? type;
+
+		if (DirectTypeMappings.TryGetValue(type, out Func<BaseType>? create))
+		{
+			return create();
+		}
+
+		if (TryGetCollectionElementType(type, out Type? elementType, out ContainerName? container) && elementType is not null && container is not null)
+		{
+			BaseType element = GetOrCreateSchemaType(schema, elementType) ?? new None();
+			return new Array() { ElementType = element, Container = container };
+		}
+		else if (type.IsEnum)
+		{
+			EnumName enumName = type.Name.As<EnumName>();
+			SchemaEnum? schemaEnum = schema.GetEnum(enumName) ?? schema.AddEnum(enumName);
+			if (schemaEnum is not null)
+			{
+				// Add enum values
+				foreach (string enumValue in System.Enum.GetNames(type))
+				{
+					schemaEnum.TryAddValue(enumValue.As<EnumValueName>());
+				}
+				return new Enum() { EnumName = enumName };
+			}
+		}
+		else if (type.IsClass && type != typeof(string))
+		{
+			ClassName className = type.Name.As<ClassName>();
+			SchemaClass? schemaClass = schema.GetClass(className) ?? Import(schema, type);
+			if (schemaClass is not null)
+			{
+				return new Object() { ClassName = className };
+			}
+		}
+
+		return new None();
+	}
+
+	/// <summary>
+	/// Restores an array's key member from the attribute a generator wrote it into.
+	/// </summary>
+	/// <remarks>
+	/// The CLR type of a keyed map carries the key's type but not which member it came from, so
+	/// this is the only place that information survives a trip through generated code.
+	/// </remarks>
+	private static void ApplySchemaKey(BaseType schemaType, MemberInfo member)
+	{
+		if (schemaType is Array arrayType &&
+			member.GetCustomAttribute<Runtime.SchemaKeyAttribute>() is Runtime.SchemaKeyAttribute key)
+		{
+			arrayType.Key = key.KeyMemberName.As<MemberName>();
+		}
+	}
+
+	/// <summary>
+	/// Restores a member's semantic metadata from the attributes a generator wrote it into.
+	/// </summary>
+	/// <remarks>
+	/// A generated property's type carries none of this: a <c>float</c> measured in metres per
+	/// second is the same <c>float</c> as one measured in nothing. The attributes are where it
+	/// survives a trip through generated code, so this is the inverse of what the C# generator
+	/// emits, and the generate-then-reimport round trip fails if either side changes alone.
+	/// <para>
+	/// An attribute that is absent leaves the property as it was rather than clearing it, so
+	/// reimporting into a member that already carries metadata adds to it instead of erasing it.
+	/// </para>
+	/// </remarks>
+	private static void ApplyMemberMetadata(SchemaMember member, MemberInfo info)
+	{
+		if (info.GetCustomAttribute<Runtime.SchemaUnitAttribute>() is Runtime.SchemaUnitAttribute unit)
+		{
+			member.Unit = unit.Unit.As<UnitSymbol>();
+		}
+
+		if (info.GetCustomAttribute<Runtime.SchemaRangeAttribute>() is Runtime.SchemaRangeAttribute range)
+		{
+			member.Range = new MemberRange { Minimum = range.Minimum, Maximum = range.Maximum, Wrap = range.Wrap };
+		}
+
+		if (info.GetCustomAttribute<Runtime.SchemaDefaultAttribute>() is Runtime.SchemaDefaultAttribute defaultValue)
+		{
+			// The constructor the generator chose is what says which kind of default this is, and
+			// the boxed value is the only thing that still remembers which one that was.
+			member.DefaultValue = defaultValue.Value switch
+			{
+				double number => new NumberDefault { Value = number },
+				bool boolean => new BooleanDefault { Value = boolean },
+				string text => new TextDefault { Value = text },
+				_ => null,
+			};
+		}
+
+		if (info.GetCustomAttribute<Runtime.SchemaInterpolationAttribute>() is Runtime.SchemaInterpolationAttribute interpolation)
+		{
+			member.Interpolation = interpolation.Mode;
+		}
+
+		if (info.GetCustomAttribute<Runtime.SchemaNetworkAttribute>() is Runtime.SchemaNetworkAttribute network)
+		{
+			member.Network = new MemberNetwork { Quantise = network.Quantise, Delta = network.Delta };
+		}
+
+		if (info.GetCustomAttribute<Runtime.SchemaEditorHintAttribute>() is Runtime.SchemaEditorHintAttribute editor)
+		{
+			member.Editor = editor.Hint.As<EditorHint>();
+		}
+	}
+
+	/// <summary>
+	/// The CLR types that map straight onto a schema type, with no further inspection.
+	/// </summary>
+	/// <remarks>
+	/// A table rather than a chain of comparisons: it reads as the mapping it is, and it is the
+	/// exact inverse of what a code generator emits, so the two can be checked against each other.
+	/// The vector types are <see cref="System.Numerics"/> ones and the colours are the types this
+	/// library provides, because the base class library has none - without them, reimporting
+	/// generated code would turn a Vector3 member into an object referencing a class called
+	/// "Vector3" and the generate-then-reimport round trip would not hold.
+	/// </remarks>
+	private static readonly Dictionary<Type, Func<BaseType>> DirectTypeMappings = new()
+	{
+		[typeof(string)] = () => new String(),
+		[typeof(int)] = () => new Int(),
+		[typeof(short)] = () => new Int(),
+		[typeof(byte)] = () => new Int(),
+		[typeof(long)] = () => new Long(),
+		[typeof(float)] = () => new Float(),
+		[typeof(double)] = () => new Double(),
+		[typeof(decimal)] = () => new Double(),
+		[typeof(bool)] = () => new Bool(),
+		[typeof(System.DateTime)] = () => new DateTime(),
+		[typeof(System.TimeSpan)] = () => new TimeSpan(),
+		[typeof(System.Numerics.Vector2)] = () => new Vector2(),
+		[typeof(System.Numerics.Vector3)] = () => new Vector3(),
+		[typeof(System.Numerics.Vector4)] = () => new Vector4(),
+		[typeof(Runtime.ColorRgb)] = () => new ColorRGB(),
+		[typeof(Runtime.ColorRgba)] = () => new ColorRGBA(),
+	};
+
+	private static bool TryGetCollectionElementType(Type type, out Type? elementType, out ContainerName? container)
+	{
+		elementType = null;
+		container = null;
+
+		if (type == typeof(string))
+		{
+			return false;
+		}
+
+		if (type.IsArray)
+		{
+			elementType = type.GetElementType();
+			container = Types.Array.VectorContainer.As<ContainerName>();
+			return elementType is not null;
+		}
+
+		Type? dictionaryInterface = GetGenericInterface(type, typeof(IDictionary<,>));
+		if (dictionaryInterface is not null)
+		{
+			elementType = dictionaryInterface.GetGenericArguments()[1];
+			container = Types.Array.MapContainer.As<ContainerName>();
+			return true;
+		}
+
+		Type? enumerableInterface = GetGenericInterface(type, typeof(IEnumerable<>));
+		if (enumerableInterface is not null)
+		{
+			elementType = enumerableInterface.GetGenericArguments()[0];
+			container = Types.Array.VectorContainer.As<ContainerName>();
+			return true;
+		}
+
+		return false;
+	}
+
+	private static Type? GetGenericInterface(Type type, Type genericInterfaceDefinition) =>
+		type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericInterfaceDefinition
+			? type
+			: System.Array.Find(type.GetInterfaces(), i => i.IsGenericType && i.GetGenericTypeDefinition() == genericInterfaceDefinition);
+}

--- a/Schema/Models/Metadata/EditorHint.cs
+++ b/Schema/Models/Metadata/EditorHint.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// Suggests how an editor should present a member.
+/// </summary>
+/// <remarks>
+/// Free text on purpose. The set of useful controls is open — a dial, a colour wheel, a curve,
+/// a file picker — and an enum here would have to be extended in this library every time a
+/// consumer invented one. An editor that does not recognise a hint falls back to the control
+/// the member's type implies, so an unknown hint costs nothing.
+/// </remarks>
+public sealed record class EditorHint : SemanticString<EditorHint> { }

--- a/Schema/Models/Metadata/Interpolation.cs
+++ b/Schema/Models/Metadata/Interpolation.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// How two states of a member may be blended.
+/// </summary>
+/// <remarks>
+/// Not every value has a meaningful midpoint. Halfway between two enum values, two identifiers
+/// or two strings is not a value of that type at all, so <see cref="None"/> is the default and
+/// anything else is a claim the schema author is making.
+/// </remarks>
+/// <remarks>
+/// Written to the file by name rather than by ordinal. An ordinal would mean that inserting a
+/// mode into this enum silently changed the meaning of every schema already written — the same
+/// reason an enum default is stored as a value's name.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter<Interpolation>))]
+public enum Interpolation
+{
+	/// <summary>
+	/// The member is not interpolated. A consumer blending between two states should hold the
+	/// earlier value until the later one applies.
+	/// </summary>
+	None,
+
+	/// <summary>
+	/// Blended linearly between the two values.
+	/// </summary>
+	Linear,
+
+	/// <summary>
+	/// Blended along the shortest arc. Correct for orientations and for angles that wrap,
+	/// where linear blending would take the long way round the discontinuity.
+	/// </summary>
+	Spherical,
+
+	/// <summary>
+	/// Held at the earlier value and changed at the later one, with no intermediate value.
+	/// Distinct from <see cref="None"/>: this says stepping is the intended behaviour rather
+	/// than that interpolation is meaningless.
+	/// </summary>
+	Step,
+}

--- a/Schema/Models/Metadata/MemberDefault.cs
+++ b/Schema/Models/Metadata/MemberDefault.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// The value a member takes when none is supplied.
+/// </summary>
+/// <remarks>
+/// Polymorphic rather than a single string, matching how <see cref="Types.BaseType"/> is
+/// modelled: an editor can then offer a number box for a number and a picker for an enum
+/// without parsing text to find out which it has, and a malformed default is a load-time
+/// failure rather than something every consumer rediscovers.
+/// <para>
+/// A default is not the same as a zeroed value, and the distinction matters wherever zeroed
+/// memory is a valid instance: <c>default(T)</c> in C# and a value-initialised struct in C++
+/// are all-zero bytes, which is rarely what a schema means by "the default".
+/// </para>
+/// </remarks>
+[JsonDerivedType(typeof(NumberDefault), nameof(NumberDefault))]
+[JsonDerivedType(typeof(BooleanDefault), nameof(BooleanDefault))]
+[JsonDerivedType(typeof(TextDefault), nameof(TextDefault))]
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "DefaultKind")]
+public abstract class MemberDefault
+{
+	/// <summary>
+	/// Returns the value in a form suitable for display.
+	/// </summary>
+	/// <returns>The default value as text.</returns>
+	public abstract override string ToString();
+}
+
+/// <summary>
+/// A numeric default, for integral, decimal and vector members.
+/// </summary>
+public sealed class NumberDefault : MemberDefault
+{
+	/// <summary>
+	/// Gets the value, in the member's own unit.
+	/// </summary>
+	/// <remarks>
+	/// Held as a <see cref="double"/> whatever the member's numeric type, so that one class
+	/// covers every numeric member. A consumer narrows it to the member's type, and
+	/// validation is what checks the value survives that narrowing.
+	/// </remarks>
+	public double Value { get; init; }
+
+	/// <inheritdoc />
+	public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+}
+
+/// <summary>
+/// A boolean default.
+/// </summary>
+public sealed class BooleanDefault : MemberDefault
+{
+	/// <summary>
+	/// Gets the value.
+	/// </summary>
+	public bool Value { get; init; }
+
+	/// <inheritdoc />
+	public override string ToString() => Value ? "true" : "false";
+}
+
+/// <summary>
+/// A textual default: the contents of a string member, or the name of an enum value.
+/// </summary>
+public sealed class TextDefault : MemberDefault
+{
+	/// <summary>
+	/// Gets the value.
+	/// </summary>
+	/// <remarks>
+	/// For an enum member this is the value's name rather than its ordinal, so reordering an
+	/// enum cannot silently change what the default means.
+	/// </remarks>
+	public string Value { get; init; } = string.Empty;
+
+	/// <inheritdoc />
+	public override string ToString() => Value;
+}

--- a/Schema/Models/Metadata/MemberNetwork.cs
+++ b/Schema/Models/Metadata/MemberNetwork.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// How a member should be encoded when its value is sent over a network.
+/// </summary>
+/// <remarks>
+/// Neither of these is expressible in the member's type, which is why they belong to the
+/// schema: the type says what a value <em>is</em>, and this says what a peer needs to know
+/// about it. Both are advisory — a codec that ignores them is still correct, just larger.
+/// </remarks>
+public sealed class MemberNetwork
+{
+	/// <summary>
+	/// Gets the smallest change worth transmitting, in the member's own unit.
+	/// </summary>
+	/// <remarks>
+	/// Zero means send the value at full precision. A velocity good to a centimetre per
+	/// second does not need thirty-two bits, and the quantised value is what a codec puts on
+	/// the wire, so the round trip is accurate to half of this and no better.
+	/// </remarks>
+	public double Quantise { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the member should be sent only when it differs from
+	/// the last state the peer acknowledged.
+	/// </summary>
+	public bool Delta { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the member is quantised.
+	/// </summary>
+	/// <remarks>
+	/// Not serialized: it is derived from <see cref="Quantise"/>.
+	/// </remarks>
+	[JsonIgnore]
+	public bool IsQuantised => Quantise > 0.0;
+
+	/// <summary>
+	/// Returns the encoding as text.
+	/// </summary>
+	/// <returns>A description of the quantisation and delta settings.</returns>
+	public override string ToString() =>
+		$"{(IsQuantised ? $"quantised to {Quantise}" : "full precision")}{(Delta ? ", delta encoded" : string.Empty)}";
+}

--- a/Schema/Models/Metadata/MemberRange.cs
+++ b/Schema/Models/Metadata/MemberRange.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// The range of values a member is allowed to take.
+/// </summary>
+/// <remarks>
+/// Expressed in the member's own unit when it has one, so a range on a member measured in
+/// <c>km</c> is in kilometres, not metres.
+/// </remarks>
+public sealed class MemberRange
+{
+	/// <summary>
+	/// Gets the smallest allowed value.
+	/// </summary>
+	public double Minimum { get; init; }
+
+	/// <summary>
+	/// Gets the largest allowed value.
+	/// </summary>
+	public double Maximum { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether values outside the range wrap into it rather than
+	/// being invalid.
+	/// </summary>
+	/// <remarks>
+	/// For a cyclic quantity the range is a period, not a bound: an angle of 7 radians on a
+	/// <c>[0, 2π)</c> member is un-normalised rather than wrong, and clamping it to the
+	/// maximum would be the one transformation that is certainly incorrect. A validator
+	/// should reduce a wrapping value into range; it should reject a non-wrapping one.
+	/// </remarks>
+	public bool Wrap { get; init; }
+
+	/// <summary>
+	/// Gets a value indicating whether the range is satisfiable.
+	/// </summary>
+	/// <remarks>
+	/// Not serialized: it is derived from the two bounds beside it, and writing it would put
+	/// a second, independently editable copy of that fact in the file.
+	/// </remarks>
+	[JsonIgnore]
+	public bool IsWellFormed => Minimum <= Maximum;
+
+	/// <summary>
+	/// Returns the range in interval notation.
+	/// </summary>
+	/// <returns>A string such as <c>[0, 1]</c>, suffixed when the range wraps.</returns>
+	public override string ToString() =>
+		$"[{Minimum}, {Maximum}]{(Wrap ? " (wraps)" : string.Empty)}";
+}

--- a/Schema/Models/Metadata/UnitRegistry.cs
+++ b/Schema/Models/Metadata/UnitRegistry.cs
@@ -136,6 +136,35 @@ public static class UnitRegistry
 	}
 
 	/// <summary>
+	/// Gets the text a schema should write to mean this unit.
+	/// </summary>
+	/// <param name="unit">The unit to name.</param>
+	/// <returns>
+	/// The unit's symbol when that symbol belongs to it alone, and its name when the symbol is
+	/// shared.
+	/// </returns>
+	/// <remarks>
+	/// A picker knows which unit was chosen, so it should never write text that loses that. The
+	/// symbol is what a person reads, and is right for all but two units in the registry; for
+	/// those two -- <c>g</c> and <c>rad</c> -- the symbol would not resolve back, so the name is
+	/// written instead. Choosing per unit rather than always writing the name keeps the common
+	/// case readable.
+	/// </remarks>
+	/// <exception cref="ArgumentNullException"><paramref name="unit"/> is null.</exception>
+	public static string PreferredText(IUnit unit)
+	{
+		Ensure.NotNull(unit);
+
+		Registry registry = Lookup.Value;
+		bool symbolIdentifiesIt =
+			!registry.ByName.ContainsKey(unit.Symbol) &&
+			registry.BySymbol.TryGetValue(unit.Symbol, out List<IUnit>? sharing) &&
+			sharing.Count == 1;
+
+		return symbolIdentifiesIt ? unit.Symbol : unit.Name;
+	}
+
+	/// <summary>
 	/// Resolves unit text to a unit, or throws.
 	/// </summary>
 	/// <param name="text">A unit symbol or unit name.</param>

--- a/Schema/Models/Metadata/UnitRegistry.cs
+++ b/Schema/Models/Metadata/UnitRegistry.cs
@@ -1,0 +1,148 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using ktsu.Semantics.Quantities;
+using ktsu.Semantics.Quantities.Units;
+
+/// <summary>
+/// Resolves the unit text written in a schema to a unit from
+/// <c>ktsu.Semantics.Quantities</c>.
+/// </summary>
+/// <remarks>
+/// The registry is built by reflecting over every <see cref="IUnit"/> in the quantities
+/// assembly rather than being a list maintained here. That is deliberate: a hand-maintained
+/// copy would be a second source of truth for conversion factors, and would silently fall
+/// behind every unit added upstream. The cost is one reflection pass, done once.
+/// </remarks>
+public static class UnitRegistry
+{
+	private static readonly Lazy<Registry> Lookup = new(Build, isThreadSafe: true);
+
+	private sealed class Registry
+	{
+		// Ordinal, not OrdinalIgnoreCase. Unit names are PascalCase and unique, so
+		// case-insensitivity buys nothing -- and it actively breaks disambiguation:
+		// "rad" would match the *name* Rad (radiation absorbed dose) before the
+		// symbol lookup ran, silently resolving to a different dimension instead of
+		// reporting that the symbol is shared with Radian. Found by running it.
+		public Dictionary<string, IUnit> ByName { get; } = new(StringComparer.Ordinal);
+
+		// A list, not a single unit: symbols are not unique. Ambiguity is reported to the
+		// caller rather than resolved by picking one, because picking one silently would
+		// mean a schema saying "rad" got radians or radiation dose depending on assembly
+		// load order.
+		public Dictionary<string, List<IUnit>> BySymbol { get; } = new(StringComparer.Ordinal);
+	}
+
+	private static Registry Build()
+	{
+		Registry registry = new();
+
+		foreach (Type type in typeof(Meter).Assembly.GetTypes())
+		{
+			if (type.IsAbstract || !type.IsClass || !typeof(IUnit).IsAssignableFrom(type))
+			{
+				continue;
+			}
+
+			// Every generated unit is a record with a public parameterless constructor.
+			// One that is not is not a unit this registry can offer.
+			if (type.GetConstructor(Type.EmptyTypes) is null)
+			{
+				continue;
+			}
+
+			if (Activator.CreateInstance(type) is not IUnit unit)
+			{
+				continue;
+			}
+
+			registry.ByName[unit.Name] = unit;
+
+			if (!registry.BySymbol.TryGetValue(unit.Symbol, out List<IUnit>? sharing))
+			{
+				sharing = [];
+				registry.BySymbol[unit.Symbol] = sharing;
+			}
+
+			sharing.Add(unit);
+		}
+
+		return registry;
+	}
+
+	/// <summary>
+	/// Gets every unit the registry knows, ordered by name.
+	/// </summary>
+	/// <remarks>
+	/// Exposed so an editor can offer a unit picker without reflecting over the quantities
+	/// assembly itself.
+	/// </remarks>
+	public static ReadOnlyCollection<IUnit> All =>
+		Lookup.Value.ByName.Values.OrderBy(unit => unit.Name, StringComparer.Ordinal).ToList().AsReadOnly();
+
+	/// <summary>
+	/// Resolves unit text to a unit.
+	/// </summary>
+	/// <param name="text">A unit symbol (<c>m/s</c>) or unit name (<c>MeterPerSecond</c>).</param>
+	/// <param name="unit">The resolved unit, or null when the text does not resolve.</param>
+	/// <param name="error">
+	/// Why it did not resolve, phrased for the person who wrote the schema. Empty on success.
+	/// </param>
+	/// <returns><see langword="true"/> when the text resolved to exactly one unit.</returns>
+	/// <remarks>
+	/// Names are tried before symbols. Every name is unique, so a name always resolves to one
+	/// unit; a symbol may not, and the ambiguous case is what names exist to escape.
+	/// </remarks>
+	public static bool TryResolve(string? text, out IUnit? unit, out string error)
+	{
+		unit = null;
+		error = string.Empty;
+
+		if (string.IsNullOrWhiteSpace(text))
+		{
+			error = "no unit given";
+			return false;
+		}
+
+		Registry registry = Lookup.Value;
+
+		if (registry.ByName.TryGetValue(text, out IUnit? named))
+		{
+			unit = named;
+			return true;
+		}
+
+		if (!registry.BySymbol.TryGetValue(text, out List<IUnit>? sharing))
+		{
+			error = $"'{text}' is not a known unit symbol or unit name";
+			return false;
+		}
+
+		if (sharing.Count > 1)
+		{
+			string candidates = string.Join(", ", sharing.Select(candidate => candidate.Name).OrderBy(name => name, StringComparer.Ordinal));
+			error = $"'{text}' is ambiguous: it is the symbol of {candidates}. Write the unit's name instead of its symbol.";
+			return false;
+		}
+
+		unit = sharing[0];
+		return true;
+	}
+
+	/// <summary>
+	/// Resolves unit text to a unit, or throws.
+	/// </summary>
+	/// <param name="text">A unit symbol or unit name.</param>
+	/// <returns>The resolved unit.</returns>
+	/// <exception cref="ArgumentException">The text is not a known, unambiguous unit.</exception>
+	public static IUnit Resolve(string? text) =>
+		TryResolve(text, out IUnit? unit, out string error) && unit is not null
+			? unit
+			: throw new ArgumentException(error, nameof(text));
+}

--- a/Schema/Models/Metadata/UnitSymbol.cs
+++ b/Schema/Models/Metadata/UnitSymbol.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Models.Metadata;
+
+using ktsu.Semantics.Strings;
+
+/// <summary>
+/// Names the unit a member's values are measured in, as written in the schema file.
+/// </summary>
+/// <remarks>
+/// Either a unit's symbol (<c>m/s</c>) or its name (<c>MeterPerSecond</c>). Symbols read better
+/// and are what a person types; names exist because two symbols in the registry are ambiguous
+/// (<c>g</c> is both gram and standard gravity, <c>rad</c> both radian and radiation absorbed
+/// dose) and a schema must be able to say which one it meant.
+/// <para>
+/// The text is what is persisted, not a resolved unit object: it stays readable in a
+/// <c>.schema.json</c>, and the conversion factors stay owned by
+/// <c>ktsu.Semantics.Quantities</c> rather than being copied into every schema file that uses
+/// them. <see cref="UnitRegistry"/> resolves it.
+/// </para>
+/// </remarks>
+public sealed record class UnitSymbol : SemanticString<UnitSymbol> { }

--- a/Schema/Models/Schema.Validation.cs
+++ b/Schema/Models/Schema.Validation.cs
@@ -173,9 +173,16 @@ public partial class Schema
 		if (!member.Range.IsWellFormed)
 		{
 			Report(issues, path, member, $"The range minimum ({Number(member.Range.Minimum)}) is above its maximum ({Number(member.Range.Maximum)}), so no value satisfies it.");
+
+			// A backwards range has no width to ask about, and saying so as well would be two
+			// messages for one mistake.
+			return;
 		}
 
-		if (member.Range.Wrap && member.Range.Minimum == member.Range.Maximum)
+		// The range is well formed by here, so its maximum is at or above its minimum and this
+		// says the two are the same value -- without comparing two doubles for equality, which is
+		// brittle enough that the analyzers refuse it.
+		if (member.Range.Wrap && member.Range.Maximum <= member.Range.Minimum)
 		{
 			Report(issues, path, member, "A wrapping range of zero width has no values to wrap into.");
 		}
@@ -198,7 +205,11 @@ public partial class Schema
 					return;
 				}
 
-				if (member.Type.IsIntegral && number.Value != Math.Truncate(number.Value))
+				// double.IsInteger rather than a comparison against Math.Truncate: it asks the
+				// question directly, and it does not compare two doubles for equality. It also
+				// answers false for an infinity, which is not a whole number and cannot narrow to
+				// one - the comparison called that whole, since truncating an infinity returns it.
+				if (member.Type.IsIntegral && !double.IsInteger(number.Value))
 				{
 					Report(issues, path, member, $"The default {Number(number.Value)} is not a whole number, but the member is {member.Type.TypeName}.");
 				}

--- a/Schema/Models/Schema.Validation.cs
+++ b/Schema/Models/Schema.Validation.cs
@@ -3,6 +3,9 @@
 namespace ktsu.Schema.Models;
 
 using System.Collections.ObjectModel;
+using System.Globalization;
+using ktsu.Semantics.Quantities;
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Types;
 
 /// <summary>
@@ -104,9 +107,234 @@ public partial class Schema
 				}
 
 				ValidateType(issues, member.Type, memberPath, member);
+				ValidateMemberMetadata(issues, member, memberPath);
 			}
 		}
 	}
+
+	/// <summary>
+	/// Checks the semantic metadata on a member: its unit, range, default, interpolation and
+	/// network encoding.
+	/// </summary>
+	/// <remarks>
+	/// These are checked here rather than at the point they are set, because most of them are
+	/// only wrong in combination — a default is out of range only relative to a range, a wrap
+	/// flag means nothing without one — and a schema being edited passes through inconsistent
+	/// states that it would be unhelpful to reject one keystroke at a time.
+	/// </remarks>
+	private static void ValidateMemberMetadata(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		ValidateMemberUnit(issues, member, path);
+		ValidateMemberRange(issues, member, path);
+		ValidateMemberDefault(issues, member, path);
+		ValidateMemberInterpolation(issues, member, path);
+		ValidateMemberNetwork(issues, member, path);
+	}
+
+	/// <summary>
+	/// A unit has to resolve, and has to be on something that can carry one.
+	/// </summary>
+	private static void ValidateMemberUnit(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		if (member.Unit is null)
+		{
+			return;
+		}
+
+		if (!CanCarryUnit(member.Type))
+		{
+			Report(issues, path, member, $"A unit is meaningless on a {member.Type.TypeName} member; only numeric and vector members measure something.");
+			return;
+		}
+
+		if (!UnitRegistry.TryResolve(member.Unit, out IUnit? _, out string error))
+		{
+			Report(issues, path, member, error);
+		}
+	}
+
+	/// <summary>
+	/// A range has to be satisfiable, has to be on something orderable, and a wrap flag needs
+	/// a range to wrap into.
+	/// </summary>
+	private static void ValidateMemberRange(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		if (member.Range is null)
+		{
+			return;
+		}
+
+		if (!member.Type.IsNumeric && !IsVector(member.Type))
+		{
+			Report(issues, path, member, $"A range is meaningless on a {member.Type.TypeName} member.");
+			return;
+		}
+
+		if (!member.Range.IsWellFormed)
+		{
+			Report(issues, path, member, $"The range minimum ({Number(member.Range.Minimum)}) is above its maximum ({Number(member.Range.Maximum)}), so no value satisfies it.");
+		}
+
+		if (member.Range.Wrap && member.Range.Minimum == member.Range.Maximum)
+		{
+			Report(issues, path, member, "A wrapping range of zero width has no values to wrap into.");
+		}
+	}
+
+	/// <summary>
+	/// A default has to be of the member's own kind, and inside its range.
+	/// </summary>
+	private static void ValidateMemberDefault(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		switch (member.DefaultValue)
+		{
+			case null:
+				return;
+
+			case NumberDefault number:
+				if (!member.Type.IsNumeric && !IsVector(member.Type))
+				{
+					Report(issues, path, member, $"A numeric default does not fit a {member.Type.TypeName} member.");
+					return;
+				}
+
+				if (member.Type.IsIntegral && number.Value != Math.Truncate(number.Value))
+				{
+					Report(issues, path, member, $"The default {Number(number.Value)} is not a whole number, but the member is {member.Type.TypeName}.");
+				}
+
+				// A wrapping range is a period rather than a bound, so a value outside it is
+				// un-normalised rather than wrong -- the same reading a validator must take of
+				// live data, applied here to the default.
+				if (member.Range is { Wrap: false } range && (number.Value < range.Minimum || number.Value > range.Maximum))
+				{
+					Report(issues, path, member, $"The default {Number(number.Value)} is outside the member's own range {range}.");
+				}
+
+				return;
+
+			case BooleanDefault:
+				if (member.Type is not Bool)
+				{
+					Report(issues, path, member, $"A boolean default does not fit a {member.Type.TypeName} member.");
+				}
+
+				return;
+
+			case TextDefault text:
+				ValidateTextDefault(issues, member, path, text);
+				return;
+
+			default:
+				Report(issues, path, member, $"Unrecognised default of kind {member.DefaultValue.GetType().Name}.");
+				return;
+		}
+	}
+
+	/// <summary>
+	/// A textual default names an enum value or supplies a string; anything else is a mismatch.
+	/// </summary>
+	private static void ValidateTextDefault(Collection<SchemaValidationIssue> issues, SchemaMember member, string path, TextDefault text)
+	{
+		if (member.Type is Types.String)
+		{
+			return;
+		}
+
+		if (member.Type is not Types.Enum enumType)
+		{
+			Report(issues, path, member, $"A textual default does not fit a {member.Type.TypeName} member.");
+			return;
+		}
+
+		// An unresolved enum reference is already reported by ValidateType; saying so again
+		// here would be two messages for one problem.
+		SchemaEnum? target = enumType.ParentMember?.ParentSchema?.TryGetEnum(enumType.EnumName, out SchemaEnum? found) == true ? found : null;
+		if (target is null)
+		{
+			return;
+		}
+
+		if (!target.Values.Any(value => string.Equals(value, text.Value, StringComparison.Ordinal)))
+		{
+			string known = string.Join(", ", target.Values.Select(value => value.ToString()));
+			Report(issues, path, member, $"The default '{text.Value}' is not a value of enum '{enumType.EnumName}'. Its values are: {known}.");
+		}
+	}
+
+	/// <summary>
+	/// Interpolation is a claim that the member has a meaningful midpoint.
+	/// </summary>
+	private static void ValidateMemberInterpolation(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		if (member.Interpolation is Interpolation.None)
+		{
+			return;
+		}
+
+		if (!member.Type.IsNumeric && !IsVector(member.Type))
+		{
+			Report(issues, path, member, $"A {member.Type.TypeName} member has no meaningful value between two states, so it cannot be interpolated.");
+			return;
+		}
+
+		// Stepping is a scheduling decision, not a geometric one, so it is the one mode that
+		// makes sense without an arc.
+		if (member.Interpolation is Interpolation.Spherical && member.Range is { Wrap: false } && !IsVector(member.Type))
+		{
+			Report(issues, path, member, "Spherical interpolation takes the shortest arc, which needs a cyclic member: give the range wrap = true, or use linear interpolation.", SchemaValidationSeverity.Warning);
+		}
+	}
+
+	/// <summary>
+	/// A quantisation step has to be a step.
+	/// </summary>
+	private static void ValidateMemberNetwork(Collection<SchemaValidationIssue> issues, SchemaMember member, string path)
+	{
+		if (member.Network is null)
+		{
+			return;
+		}
+
+		if (member.Network.Quantise < 0.0)
+		{
+			Report(issues, path, member, $"A quantisation step must not be negative, but this one is {Number(member.Network.Quantise)}.");
+		}
+
+		if (member.Network.IsQuantised && !member.Type.IsNumeric && !IsVector(member.Type))
+		{
+			Report(issues, path, member, $"A {member.Type.TypeName} member has no numeric value to quantise.");
+		}
+
+		// Quantising more coarsely than the whole range leaves one representable value.
+		if (member.Network.IsQuantised && member.Range is { } bounds && bounds.IsWellFormed &&
+			member.Network.Quantise > bounds.Maximum - bounds.Minimum)
+		{
+			Report(issues, path, member, $"The quantisation step {Number(member.Network.Quantise)} is wider than the member's whole range {bounds}, so every value would encode the same.", SchemaValidationSeverity.Warning);
+		}
+	}
+
+	/// <summary>
+	/// Only something with a magnitude measures anything.
+	/// </summary>
+	private static bool CanCarryUnit(BaseType type) => type.IsNumeric || IsVector(type);
+
+	private static bool IsVector(BaseType type) => type is Vector2 or Vector3 or Vector4;
+
+	/// <summary>
+	/// Formats a number for a message, culture-invariantly: a validation message that says
+	/// "0,5" on one machine and "0.5" on another is a support problem.
+	/// </summary>
+	private static string Number(double value) => value.ToString(CultureInfo.InvariantCulture);
+
+	private static void Report(Collection<SchemaValidationIssue> issues, string path, ISchemaElement element, string message, SchemaValidationSeverity severity = SchemaValidationSeverity.Error) =>
+		issues.Add(new()
+		{
+			Severity = severity,
+			Path = path,
+			Message = message,
+			Element = element,
+		});
 
 	private void ValidateEnums(Collection<SchemaValidationIssue> issues)
 	{

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -3,7 +3,6 @@
 namespace ktsu.Schema.Models;
 
 using System.Collections.ObjectModel;
-using System.Reflection;
 using System.Text.Json.Serialization;
 using ktsu.Schema.Contracts;
 using ktsu.Schema.Contracts.Names;
@@ -470,182 +469,14 @@ public partial class Schema : ISchema
 	/// <summary>
 	/// Adds a class based on a .NET Type.
 	/// </summary>
+	/// <remarks>
+	/// The reflection that reads the type lives in <see cref="ClrTypeImporter"/>, which is the
+	/// inverse of what the C# generator emits and is checked against it by the
+	/// generate-then-reimport round trip.
+	/// </remarks>
 	/// <param name="type">The .NET type to add as a schema class.</param>
 	/// <returns>The added class if successful, null otherwise.</returns>
-	public SchemaClass? AddClass(Type type)
-	{
-		Ensure.NotNull(type);
-
-		ClassName className = type.Name.As<ClassName>();
-		SchemaClass? schemaClass = AddClass(className);
-		if (schemaClass is not null)
-		{
-			// Add properties as members
-			foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-			{
-				MemberName memberName = property.Name.As<MemberName>();
-				SchemaMember? member = schemaClass.AddMember(memberName);
-				if (member is not null)
-				{
-					BaseType? schemaType = GetOrCreateSchemaType(property.PropertyType);
-					if (schemaType is not null)
-					{
-						ApplySchemaKey(schemaType, property);
-						member.SetType(schemaType);
-					}
-				}
-			}
-
-			// Add fields as members
-			foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance))
-			{
-				MemberName memberName = field.Name.As<MemberName>();
-				SchemaMember? member = schemaClass.AddMember(memberName);
-				if (member is not null)
-				{
-					BaseType? schemaType = GetOrCreateSchemaType(field.FieldType);
-					if (schemaType is not null)
-					{
-						ApplySchemaKey(schemaType, field);
-						member.SetType(schemaType);
-					}
-				}
-			}
-		}
-
-		return schemaClass;
-	}
-
-	private BaseType? GetOrCreateSchemaType(Type type)
-	{
-		Ensure.NotNull(type);
-
-		type = Nullable.GetUnderlyingType(type) ?? type;
-
-		if (DirectTypeMappings.TryGetValue(type, out Func<BaseType>? create))
-		{
-			return create();
-		}
-
-		if (TryGetCollectionElementType(type, out Type? elementType, out ContainerName? container) && elementType is not null && container is not null)
-		{
-			BaseType element = GetOrCreateSchemaType(elementType) ?? new None();
-			return new Array() { ElementType = element, Container = container };
-		}
-		else if (type.IsEnum)
-		{
-			EnumName enumName = type.Name.As<EnumName>();
-			SchemaEnum? schemaEnum = GetEnum(enumName) ?? AddEnum(enumName);
-			if (schemaEnum is not null)
-			{
-				// Add enum values
-				foreach (string enumValue in System.Enum.GetNames(type))
-				{
-					schemaEnum.TryAddValue(enumValue.As<EnumValueName>());
-				}
-				return new Enum() { EnumName = enumName };
-			}
-		}
-		else if (type.IsClass && type != typeof(string))
-		{
-			ClassName className = type.Name.As<ClassName>();
-			SchemaClass? schemaClass = GetClass(className) ?? AddClass(type);
-			if (schemaClass is not null)
-			{
-				return new Object() { ClassName = className };
-			}
-		}
-
-		return new None();
-	}
-
-	/// <summary>
-	/// Restores an array's key member from the attribute a generator wrote it into.
-	/// </summary>
-	/// <remarks>
-	/// The CLR type of a keyed map carries the key's type but not which member it came from, so
-	/// this is the only place that information survives a trip through generated code.
-	/// </remarks>
-	private static void ApplySchemaKey(BaseType schemaType, MemberInfo member)
-	{
-		if (schemaType is Array arrayType &&
-			member.GetCustomAttribute<Runtime.SchemaKeyAttribute>() is Runtime.SchemaKeyAttribute key)
-		{
-			arrayType.Key = key.KeyMemberName.As<MemberName>();
-		}
-	}
-
-	/// <summary>
-	/// The CLR types that map straight onto a schema type, with no further inspection.
-	/// </summary>
-	/// <remarks>
-	/// A table rather than a chain of comparisons: it reads as the mapping it is, and it is the
-	/// exact inverse of what a code generator emits, so the two can be checked against each other.
-	/// The vector types are <see cref="System.Numerics"/> ones and the colours are the types this
-	/// library provides, because the base class library has none - without them, reimporting
-	/// generated code would turn a Vector3 member into an object referencing a class called
-	/// "Vector3" and the generate-then-reimport round trip would not hold.
-	/// </remarks>
-	private static readonly Dictionary<Type, Func<BaseType>> DirectTypeMappings = new()
-	{
-		[typeof(string)] = () => new String(),
-		[typeof(int)] = () => new Int(),
-		[typeof(short)] = () => new Int(),
-		[typeof(byte)] = () => new Int(),
-		[typeof(long)] = () => new Long(),
-		[typeof(float)] = () => new Float(),
-		[typeof(double)] = () => new Double(),
-		[typeof(decimal)] = () => new Double(),
-		[typeof(bool)] = () => new Bool(),
-		[typeof(System.DateTime)] = () => new DateTime(),
-		[typeof(System.TimeSpan)] = () => new TimeSpan(),
-		[typeof(System.Numerics.Vector2)] = () => new Vector2(),
-		[typeof(System.Numerics.Vector3)] = () => new Vector3(),
-		[typeof(System.Numerics.Vector4)] = () => new Vector4(),
-		[typeof(Runtime.ColorRgb)] = () => new ColorRGB(),
-		[typeof(Runtime.ColorRgba)] = () => new ColorRGBA(),
-	};
-
-	private static bool TryGetCollectionElementType(Type type, out Type? elementType, out ContainerName? container)
-	{
-		elementType = null;
-		container = null;
-
-		if (type == typeof(string))
-		{
-			return false;
-		}
-
-		if (type.IsArray)
-		{
-			elementType = type.GetElementType();
-			container = Types.Array.VectorContainer.As<ContainerName>();
-			return elementType is not null;
-		}
-
-		Type? dictionaryInterface = GetGenericInterface(type, typeof(IDictionary<,>));
-		if (dictionaryInterface is not null)
-		{
-			elementType = dictionaryInterface.GetGenericArguments()[1];
-			container = Types.Array.MapContainer.As<ContainerName>();
-			return true;
-		}
-
-		Type? enumerableInterface = GetGenericInterface(type, typeof(IEnumerable<>));
-		if (enumerableInterface is not null)
-		{
-			elementType = enumerableInterface.GetGenericArguments()[0];
-			container = Types.Array.VectorContainer.As<ContainerName>();
-			return true;
-		}
-
-		return false;
-	}
-
-	private static Type? GetGenericInterface(Type type, Type genericInterfaceDefinition) =>
-		type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericInterfaceDefinition
-			? type
-			: System.Array.Find(type.GetInterfaces(), i => i.IsGenericType && i.GetGenericTypeDefinition() == genericInterfaceDefinition);
+	public SchemaClass? AddClass(Type type) => ClrTypeImporter.Import(this, type);
 
 	/// <summary>
 	/// Gets the first class in the schema.

--- a/Schema/Models/Schema.cs
+++ b/Schema/Models/Schema.cs
@@ -25,8 +25,18 @@ public partial class Schema : ISchema
 	/// Version 1 is the first versioned format. A file with no version field predates versioning
 	/// and is treated as version <see cref="PreVersioningFormatVersion"/>; see
 	/// <c>docs/schema-format.md</c> for the migration path and the compatibility policy.
+	/// <para>
+	/// Version 2 added the semantic metadata a member can carry: unit, range, default,
+	/// interpolation, network encoding and editor hint. Every one of them is optional and
+	/// omitted when absent, so a version 2 file with none of them is byte-identical to the
+	/// version 1 file it would have been. The version still moves, because a version 1 reader
+	/// silently ignores properties it does not know: it would load such a file, drop the
+	/// metadata, and write it back without it — which is exactly the information loss the
+	/// round-trip contract in <c>docs/schema-format.md</c> forbids. Refusing to read it is
+	/// the honest outcome.
+	/// </para>
 	/// </remarks>
-	public const int CurrentFormatVersion = 1;
+	public const int CurrentFormatVersion = 2;
 
 	/// <summary>
 	/// The version attributed to a file written before the format carried a version field.

--- a/Schema/Models/SchemaMember.cs
+++ b/Schema/Models/SchemaMember.cs
@@ -4,8 +4,10 @@ namespace ktsu.Schema.Models;
 
 using System.Text.Json.Serialization;
 using ktsu.Schema.Contracts;
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Names;
 using ktsu.Schema.Models.Types;
+using ktsu.Semantics.Quantities;
 using ktsu.Semantics.Strings;
 
 /// <summary>
@@ -73,6 +75,64 @@ public class SchemaMember : SchemaClassChild<MemberName>, ISchemaMember
 	/// </remarks>
 	void ISchemaMember.SetType(ISchemaType type) =>
 		SetType(type as BaseType ?? throw new ArgumentException($"The type must derive from {nameof(BaseType)}.", nameof(type)));
+
+	/// <summary>
+	/// Gets or sets the unit this member's values are measured in, if any.
+	/// </summary>
+	/// <remarks>
+	/// A symbol (<c>m/s</c>) or a unit name (<c>MeterPerSecond</c>), resolved against
+	/// <see cref="UnitRegistry"/>. Null on a member that measures nothing — an identifier, a
+	/// name, a flag.
+	/// <para>
+	/// The text is stored rather than a resolved unit so that the file stays readable and the
+	/// conversion factors stay owned by <c>ktsu.Semantics.Quantities</c>. Use
+	/// <see cref="TryResolveUnit"/> to get the unit itself.
+	/// </para>
+	/// </remarks>
+	public UnitSymbol? Unit { get; set; }
+
+	/// <summary>
+	/// Gets or sets the range of values this member may take, if it is bounded.
+	/// </summary>
+	public MemberRange? Range { get; set; }
+
+	/// <summary>
+	/// Gets or sets the value this member takes when none is supplied.
+	/// </summary>
+	public MemberDefault? DefaultValue { get; set; }
+
+	/// <summary>
+	/// Gets or sets how this member should be encoded when sent over a network.
+	/// </summary>
+	/// <remarks>
+	/// Null means no guidance, which a codec should read as "send it verbatim, every time".
+	/// </remarks>
+	public MemberNetwork? Network { get; set; }
+
+	/// <summary>
+	/// Gets or sets how two states of this member may be blended.
+	/// </summary>
+	public Interpolation Interpolation { get; set; }
+
+	/// <summary>
+	/// Gets or sets a hint about how an editor should present this member.
+	/// </summary>
+	public EditorHint? Editor { get; set; }
+
+	/// <summary>
+	/// Resolves <see cref="Unit"/> to a unit from <c>ktsu.Semantics.Quantities</c>.
+	/// </summary>
+	/// <param name="unit">The resolved unit, or null when the member has no unit or it does
+	/// not resolve.</param>
+	/// <param name="error">Why it did not resolve. Empty when the member has no unit at all,
+	/// since that is not an error.</param>
+	/// <returns><see langword="true"/> when the member has a unit and it resolved.</returns>
+	public bool TryResolveUnit(out IUnit? unit, out string error)
+	{
+		unit = null;
+		error = string.Empty;
+		return Unit is not null && UnitRegistry.TryResolve(Unit, out unit, out error);
+	}
 
 	/// <summary>
 	/// Tries to remove the schema member from its parent class.

--- a/Schema/Runtime/SchemaMetadataAttributes.cs
+++ b/Schema/Runtime/SchemaMetadataAttributes.cs
@@ -1,0 +1,143 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.Schema.Runtime;
+
+using ktsu.Schema.Models.Metadata;
+
+/// <summary>
+/// Records the unit a generated member's values are measured in.
+/// </summary>
+/// <remarks>
+/// The family of attributes in this file exists for the reason
+/// <see cref="SchemaKeyAttribute"/> does: a C# type says what a value <em>is</em> and nothing
+/// about what it means, so a <c>float</c> emitted for a member measured in metres per second is
+/// indistinguishable from one measured in nothing at all. Reimporting generated code would drop
+/// every one of these and give back a schema subtly different from the one that produced it.
+/// <para>
+/// The text is the same spelling the schema file holds - a symbol or a unit name - and resolves
+/// through <see cref="UnitRegistry"/>.
+/// </para>
+/// </remarks>
+/// <param name="unit">The unit's symbol or name.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaUnitAttribute(string unit) : Attribute
+{
+	/// <summary>
+	/// Gets the unit's symbol or name.
+	/// </summary>
+	public string Unit { get; } = unit;
+}
+
+/// <summary>
+/// Records the range a generated member's values may take.
+/// </summary>
+/// <param name="minimum">The smallest allowed value, in the member's own unit.</param>
+/// <param name="maximum">The largest allowed value, in the member's own unit.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaRangeAttribute(double minimum, double maximum) : Attribute
+{
+	/// <summary>
+	/// Gets the smallest allowed value.
+	/// </summary>
+	public double Minimum { get; } = minimum;
+
+	/// <summary>
+	/// Gets the largest allowed value.
+	/// </summary>
+	public double Maximum { get; } = maximum;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether values outside the range wrap into it rather than
+	/// being invalid.
+	/// </summary>
+	/// <remarks>
+	/// A named argument rather than a third constructor parameter, because it is absent from most
+	/// ranges and a bare <c>true</c> at a call site says nothing about which flag it is.
+	/// </remarks>
+	public bool Wrap { get; set; }
+}
+
+/// <summary>
+/// Records the value a generated member takes when none is supplied.
+/// </summary>
+/// <remarks>
+/// One attribute with a constructor per kind of value rather than three attributes, because a
+/// member has one default: the overload chosen at the call site is what says which kind it is,
+/// and <see cref="Value"/> hands back what that overload was given.
+/// <para>
+/// Distinct from the property initialiser a generator also emits. The initialiser makes an
+/// instance start at the default; this is what lets the default be read back off the type.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaDefaultAttribute : Attribute
+{
+	/// <summary>
+	/// Records a numeric default, for an integral, decimal or vector member.
+	/// </summary>
+	/// <param name="value">The default value.</param>
+	public SchemaDefaultAttribute(double value) => Value = value;
+
+	/// <summary>
+	/// Records a boolean default.
+	/// </summary>
+	/// <param name="value">The default value.</param>
+	public SchemaDefaultAttribute(bool value) => Value = value;
+
+	/// <summary>
+	/// Records a textual default: a string member's contents, or the name of an enum value.
+	/// </summary>
+	/// <param name="value">The default value.</param>
+	public SchemaDefaultAttribute(string value) => Value = value;
+
+	/// <summary>
+	/// Gets the default value, as a <see cref="double"/>, <see cref="bool"/> or
+	/// <see cref="string"/> according to the constructor used.
+	/// </summary>
+	public object Value { get; }
+}
+
+/// <summary>
+/// Records how two states of a generated member may be blended.
+/// </summary>
+/// <param name="mode">The interpolation mode.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaInterpolationAttribute(Interpolation mode) : Attribute
+{
+	/// <summary>
+	/// Gets the interpolation mode.
+	/// </summary>
+	public Interpolation Mode { get; } = mode;
+}
+
+/// <summary>
+/// Records how a generated member should be encoded when sent over a network.
+/// </summary>
+/// <param name="quantise">The smallest change worth transmitting. Zero means full precision.</param>
+/// <param name="delta">Whether to send the member only when it differs from the last acknowledged state.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaNetworkAttribute(double quantise, bool delta) : Attribute
+{
+	/// <summary>
+	/// Gets the smallest change worth transmitting, in the member's own unit.
+	/// </summary>
+	public double Quantise { get; } = quantise;
+
+	/// <summary>
+	/// Gets a value indicating whether the member is sent only when it has changed.
+	/// </summary>
+	public bool Delta { get; } = delta;
+}
+
+/// <summary>
+/// Records how an editor should present a generated member.
+/// </summary>
+/// <param name="hint">The hint, which is free text.</param>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class SchemaEditorHintAttribute(string hint) : Attribute
+{
+	/// <summary>
+	/// Gets the hint.
+	/// </summary>
+	public string Hint { get; } = hint;
+}

--- a/Schema/Schema.csproj
+++ b/Schema/Schema.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="ktsu.CodeBlocker" />
     <PackageReference Include="ktsu.RoundTripStringJsonConverter" />
+    <PackageReference Include="ktsu.Semantics.Quantities" />
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="ktsu.Semantics.Paths" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/SchemaEditor.Test/EditorHarness.cs
+++ b/SchemaEditor.Test/EditorHarness.cs
@@ -208,6 +208,24 @@ internal sealed class EditorHarness : IDisposable
 		App.Step(2);
 	}
 
+	/// <summary>
+	/// Empties a marked single-line field and finishes the edit.
+	/// </summary>
+	/// <remarks>
+	/// Not <c>Commit(field, "")</c>: typing an empty string types nothing, so the field is left
+	/// deactivated without having been edited and reports no value at all. Deleting the selection
+	/// is what a person does, and it is the only way to see what a field does with emptiness.
+	/// </remarks>
+	/// <param name="field">A marked name, or the trailing part of one.</param>
+	internal void Clear(string field)
+	{
+		Click(field);
+		App.Keyboard.Press(Hexa.NET.ImGui.ImGuiKey.A, ctrl: true);
+		App.Keyboard.Press(Hexa.NET.ImGui.ImGuiKey.Backspace);
+		App.Keyboard.Press(Hexa.NET.ImGui.ImGuiKey.Enter);
+		App.Step(2);
+	}
+
 	public void Dispose()
 	{
 		if (disposed)

--- a/SchemaEditor.Test/MemberSemanticsTests.cs
+++ b/SchemaEditor.Test/MemberSemanticsTests.cs
@@ -1,0 +1,362 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor.Test;
+
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Quantities;
+using ktsu.Semantics.Strings;
+
+using SchemaTypes = ktsu.Schema.Models.Types;
+
+/// <summary>
+/// The metadata panel folded behind each member row: the unit, range, default, interpolation,
+/// network encoding and editor hint a member can carry.
+/// </summary>
+/// <remarks>
+/// Driven through the real editor rather than by calling the model, because every one of these is
+/// an immediate-mode control whose value only reaches the schema through what the widget reports -
+/// which is the part that has no coverage anywhere else.
+/// </remarks>
+[TestClass]
+public sealed class MemberSemanticsTests
+{
+	private EditorHarness harness = null!;
+	private Schema schema = null!;
+	private SchemaMember speed = null!;
+
+	[TestInitialize]
+	public void StartEditor()
+	{
+		harness = EditorHarness.Start();
+		EditField.Reset();
+
+		schema = new Schema();
+		SchemaClass body = schema.AddClass("Body".As<ClassName>())!;
+		speed = body.AddMember("Speed".As<MemberName>())!;
+		speed.SetType(new SchemaTypes.Float());
+
+		harness.Editor.CurrentSchema = schema;
+		harness.Editor.EditClass(body);
+	}
+
+	[TestCleanup]
+	public void StopEditor()
+	{
+		EditField.Reset();
+		harness.Dispose();
+	}
+
+	/// <summary>
+	/// Folds the metadata panel open for the member the tests edit.
+	/// </summary>
+	private void OpenSemantics() => harness.Click("memberSpeed/ToggleSemantics");
+
+	/// <summary>
+	/// Chooses a unit from the picker, narrowing the list first.
+	/// </summary>
+	/// <remarks>
+	/// The registry holds close to two hundred units and the popup draws all of them, so a unit
+	/// past the first screenful is recorded at a position outside the popup and cannot be clicked.
+	/// Typing into the search box is what a person does too, and the selection is confirmed rather
+	/// than applied by the click that makes it.
+	/// </remarks>
+	private void ChooseUnit(string search, string option)
+	{
+		harness.Click("memberSpeed/Unit");
+		harness.TypeInto("searchable-list/search", search);
+		harness.Click($"searchable-list/{option}");
+		harness.Click("searchable-list/ok");
+	}
+
+	[TestMethod]
+	public void TheMetadataIsFoldedAwayUntilItIsAskedFor()
+	{
+		Assert.IsFalse(harness.IsOnScreen("memberSpeed/Unit"), "the panel was drawn before it was opened");
+
+		OpenSemantics();
+
+		Assert.IsTrue(harness.IsOnScreen("memberSpeed/Unit"));
+		Assert.IsTrue(harness.IsOnScreen("memberSpeed/Interpolation"));
+	}
+
+	// ------------------------------------------------------------------- units
+
+	[TestMethod]
+	public void ChoosingAUnitWritesItsSymbol()
+	{
+		OpenSemantics();
+		ChooseUnit("MeterPerSecond", "MeterPerSecond (m/s)");
+
+		Assert.AreEqual("m/s", speed.Unit?.ToString());
+	}
+
+	/// <summary>
+	/// The symbol is what a schema usually writes, but two symbols in the registry belong to more
+	/// than one unit, and one of the two is not even the same dimension. A picker knows which unit
+	/// was chosen, so it must not write text that loses that.
+	/// </summary>
+	[TestMethod]
+	public void AUnitWhoseSymbolIsSharedIsWrittenByName()
+	{
+		OpenSemantics();
+		ChooseUnit("Radian", "Radian (rad)");
+
+		Assert.AreEqual("Radian", speed.Unit?.ToString(), "'rad' is also the symbol of Rad, an absorbed radiation dose");
+		Assert.IsTrue(speed.TryResolveUnit(out IUnit? unit, out string error), error);
+		Assert.AreEqual("Radian", unit!.Name);
+	}
+
+	[TestMethod]
+	public void ChoosingAUnitIsUndoable()
+	{
+		OpenSemantics();
+		ChooseUnit("MeterPerSecond", "MeterPerSecond (m/s)");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.IsNull(speed.Unit);
+	}
+
+	// ------------------------------------------------------------------ ranges
+
+	[TestMethod]
+	public void AMemberIsUnboundedUntilARangeIsAdded()
+	{
+		OpenSemantics();
+		Assert.IsNull(speed.Range);
+		Assert.IsFalse(harness.IsOnScreen("memberSpeed/field/RangeMinimum"), "the bounds were drawn without a range");
+
+		harness.Click("memberSpeed/Bounded");
+
+		Assert.IsNotNull(speed.Range);
+		Assert.IsTrue(harness.IsOnScreen("memberSpeed/field/RangeMinimum"));
+	}
+
+	[TestMethod]
+	public void TheBoundsAreWrittenAsTyped()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/Bounded");
+
+		harness.Commit("memberSpeed/field/RangeMinimum", "-2.5");
+		harness.Commit("memberSpeed/field/RangeMaximum", "10");
+
+		Assert.AreEqual(-2.5, speed.Range?.Minimum);
+		Assert.AreEqual(10.0, speed.Range?.Maximum);
+	}
+
+	/// <summary>
+	/// A half-typed number is not a number, and the field holds one for as long as it takes to type
+	/// a negative or a decimal. Nothing reaches the schema until the edit is finished, and text
+	/// that is not a number at all leaves the bound where it was.
+	/// </summary>
+	[TestMethod]
+	public void TextThatIsNotANumberLeavesTheBoundAlone()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/Bounded");
+		harness.Commit("memberSpeed/field/RangeMaximum", "4");
+
+		harness.Commit("memberSpeed/field/RangeMaximum", "fast");
+
+		Assert.AreEqual(4.0, speed.Range?.Maximum);
+	}
+
+	[TestMethod]
+	public void ARangeCanBeMadeToWrap()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/Bounded");
+		harness.Commit("memberSpeed/field/RangeMaximum", "6.2831853");
+
+		harness.Click("memberSpeed/Wrap");
+
+		Assert.IsTrue(speed.Range?.Wrap);
+		Assert.AreEqual(6.2831853, speed.Range?.Maximum, "wrapping replaced the range rather than editing it");
+	}
+
+	/// <summary>
+	/// One entry per editing session, not per keystroke: a range is immutable, so each edit
+	/// replaces it, and an undo has to put back the range as it stood before that one edit.
+	/// </summary>
+	[TestMethod]
+	public void EditingABoundIsOneUndoEntry()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/Bounded");
+		harness.Commit("memberSpeed/field/RangeMaximum", "1");
+		harness.Commit("memberSpeed/field/RangeMaximum", "2");
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual(1.0, speed.Range?.Maximum);
+	}
+
+	// ---------------------------------------------------------------- defaults
+
+	[TestMethod]
+	public void ADefaultIsGivenAKindBeforeAValue()
+	{
+		OpenSemantics();
+		Assert.IsNull(speed.DefaultValue);
+
+		harness.Click("memberSpeed/DefaultKind");
+		harness.Click("default-kind-option/Number");
+		harness.Commit("memberSpeed/field/DefaultNumber", "12.5");
+
+		Assert.IsInstanceOfType<NumberDefault>(speed.DefaultValue);
+		Assert.AreEqual(12.5, ((NumberDefault)speed.DefaultValue!).Value);
+	}
+
+	[TestMethod]
+	public void ADefaultCanBeTakenAwayAgain()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/DefaultKind");
+		harness.Click("default-kind-option/Number");
+		Assert.IsNotNull(speed.DefaultValue);
+
+		harness.Click("memberSpeed/DefaultKind");
+		harness.Click("default-kind-option/<none>");
+
+		Assert.IsNull(speed.DefaultValue);
+	}
+
+	/// <summary>
+	/// An enum member's default is offered as the enum's own values, because a name that is not one
+	/// of them is the mistake this default invites and the schema already knows which are allowed.
+	/// </summary>
+	[TestMethod]
+	public void AnEnumMemberOffersTheValuesOfItsEnum()
+	{
+		SchemaEnum kind = schema.AddEnum("Kind".As<EnumName>())!;
+		kind.TryAddValue("Sphere".As<EnumValueName>());
+		kind.TryAddValue("Box".As<EnumValueName>());
+
+		SchemaClass collider = schema.AddClass("Collider".As<ClassName>())!;
+		SchemaMember shape = collider.AddMember("Shape".As<MemberName>())!;
+		shape.SetType(new SchemaTypes.Enum { EnumName = "Kind".As<EnumName>() });
+		harness.Editor.EditClass(collider);
+
+		harness.Click("memberShape/ToggleSemantics");
+		harness.Click("memberShape/DefaultKind");
+		harness.Click("default-kind-option/Text");
+		harness.Click("memberShape/DefaultEnumValue");
+		harness.Click("enum-default-option/Box");
+
+		Assert.AreEqual("Box", shape.DefaultValue?.ToString());
+		Assert.AreEqual(0, harness.Editor.CurrentSchema!.Validate().Count(issue => issue.Severity == SchemaValidationSeverity.Error));
+	}
+
+	// ----------------------------------------------------------- interpolation
+
+	[TestMethod]
+	public void ChoosingAnInterpolationModeSetsIt()
+	{
+		OpenSemantics();
+
+		harness.Click("memberSpeed/Interpolation");
+		harness.Click("interpolation-option/Linear");
+
+		Assert.AreEqual(Interpolation.Linear, speed.Interpolation);
+
+		harness.Editor.UndoRedo.Undo();
+
+		Assert.AreEqual(Interpolation.None, speed.Interpolation);
+	}
+
+	// ------------------------------------------------------------- networking
+
+	[TestMethod]
+	public void AMemberCarriesNoNetworkGuidanceUntilItIsAsked()
+	{
+		OpenSemantics();
+		Assert.IsNull(speed.Network);
+		Assert.IsFalse(harness.IsOnScreen("memberSpeed/field/Quantise"), "the step was drawn without an encoding");
+
+		harness.Click("memberSpeed/Encoded");
+
+		Assert.IsNotNull(speed.Network);
+		Assert.IsFalse(speed.Network!.IsQuantised, "a new encoding should send full precision");
+	}
+
+	[TestMethod]
+	public void TheQuantisationStepAndDeltaFlagAreWritten()
+	{
+		OpenSemantics();
+		harness.Click("memberSpeed/Encoded");
+
+		harness.Commit("memberSpeed/field/Quantise", "0.01");
+		harness.Click("memberSpeed/Delta");
+
+		Assert.AreEqual(0.01, speed.Network?.Quantise);
+		Assert.IsTrue(speed.Network?.Delta);
+		Assert.IsTrue(speed.Network?.IsQuantised);
+	}
+
+	// ------------------------------------------------------------ editor hint
+
+	[TestMethod]
+	public void TheEditorHintIsFreeText()
+	{
+		OpenSemantics();
+
+		harness.Commit("memberSpeed/field/EditorHint", "dial");
+
+		Assert.AreEqual("dial", speed.Editor?.ToString());
+	}
+
+	/// <summary>
+	/// Emptying the field removes the hint rather than writing an empty one, so the property leaves
+	/// the file instead of sitting in it saying nothing.
+	/// </summary>
+	[TestMethod]
+	public void ClearingTheEditorHintRemovesIt()
+	{
+		OpenSemantics();
+		harness.Commit("memberSpeed/field/EditorHint", "dial");
+
+		harness.Clear("memberSpeed/field/EditorHint");
+
+		Assert.IsNull(speed.Editor);
+	}
+
+	// ------------------------------------------------------------ folded state
+
+	/// <summary>
+	/// A folded row is the only place most members are ever seen, so it has to say whether there is
+	/// anything behind the fold.
+	/// </summary>
+	[TestMethod]
+	public void AFoldedRowSaysWhetherThereIsAnythingBehindIt()
+	{
+		Assert.IsFalse(MemberSemanticsPanel.HasSemantics(speed));
+		StringAssert.Contains(MemberSemanticsPanel.DescribeSemantics(speed), "No unit");
+
+		speed.Unit = "m/s".As<UnitSymbol>();
+		speed.Range = new MemberRange { Minimum = 0.0, Maximum = 10.0 };
+		speed.Interpolation = Interpolation.Linear;
+
+		Assert.IsTrue(MemberSemanticsPanel.HasSemantics(speed));
+
+		string summary = MemberSemanticsPanel.DescribeSemantics(speed);
+		StringAssert.Contains(summary, "in m/s");
+		StringAssert.Contains(summary, "[0, 10]");
+		StringAssert.Contains(summary, "linear");
+	}
+
+	/// <summary>
+	/// Interpolation alone counts, because it is the one property whose absence is a value rather
+	/// than a null - so asking whether it is set has to mean asking whether it is
+	/// <see cref="Interpolation.None"/>.
+	/// </summary>
+	[TestMethod]
+	public void InterpolationAloneIsEnoughToCountAsMetadata()
+	{
+		speed.Interpolation = Interpolation.Step;
+
+		Assert.IsTrue(MemberSemanticsPanel.HasSemantics(speed));
+	}
+}

--- a/SchemaEditor/EditField.cs
+++ b/SchemaEditor/EditField.cs
@@ -3,6 +3,7 @@
 namespace ktsu.SchemaEditor;
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
 
 using Hexa.NET.ImGui;
@@ -55,6 +56,49 @@ internal static class EditField
 		Mark(id);
 
 		return Resolve(key, buffer, modelValue, out committed);
+	}
+
+	/// <summary>
+	/// Draws a text input bound to a numeric model value.
+	/// </summary>
+	/// <remarks>
+	/// Text rather than ImGui's own numeric input, for the reason the rest of this class exists:
+	/// <c>InputDouble</c> reports its value every frame, so a range bound edited through it would
+	/// push an undo entry per keystroke. Text also lets the field hold what a number cannot -
+	/// "-", "0.", an empty box mid-edit - without the model seeing any of it.
+	/// <para>
+	/// Parsed invariantly, matching how the value is written to the schema file. A machine whose
+	/// locale writes a decimal comma would otherwise produce a file another machine reads
+	/// differently.
+	/// </para>
+	/// </remarks>
+	/// <param name="id">The widget id, which also keys the scratch buffer.</param>
+	/// <param name="width">The item width.</param>
+	/// <param name="modelValue">The value currently held by the model.</param>
+	/// <param name="committed">The value to write, valid only when this returns true.</param>
+	/// <returns>True on the frame the user finished editing with a different, parsable number.</returns>
+	internal static bool Number(string id, float width, double modelValue, out double committed)
+	{
+		committed = modelValue;
+
+		string text = modelValue.ToString(CultureInfo.InvariantCulture);
+		if (!Text(id, width, text, out string edited))
+		{
+			return false;
+		}
+
+		// An unparsable value is discarded rather than reported: the field has already been
+		// deactivated, so the next frame redraws it from the model and the nonsense disappears.
+		if (!double.TryParse(edited, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed))
+		{
+			return false;
+		}
+
+		committed = parsed;
+
+		// Equals rather than !=, because "1.0" and "1" are different text and the same number,
+		// and only a changed number is worth an undo entry.
+		return !parsed.Equals(modelValue);
 	}
 
 	/// <summary>

--- a/SchemaEditor/EditField.cs
+++ b/SchemaEditor/EditField.cs
@@ -96,9 +96,11 @@ internal static class EditField
 
 		committed = parsed;
 
-		// Equals rather than !=, because "1.0" and "1" are different text and the same number,
-		// and only a changed number is worth an undo entry.
-		return !parsed.Equals(modelValue);
+		// Compared as the text the field is bound to rather than as two doubles, because only a
+		// changed number is worth an undo entry and "1.0" and "1" are different text and the same
+		// number. Rendering both and comparing the strings answers that without an exact
+		// floating-point comparison, which is brittle enough that the analyzers refuse it.
+		return !string.Equals(parsed.ToString(CultureInfo.InvariantCulture), text, StringComparison.Ordinal);
 	}
 
 	/// <summary>

--- a/SchemaEditor/MemberGridPanel.cs
+++ b/SchemaEditor/MemberGridPanel.cs
@@ -1,0 +1,360 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using System.Linq;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Probes;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Names;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+using SchemaTypes = Schema.Models.Types;
+
+/// <summary>
+/// The grid of member rows in the class panel: the controls that add, reorder, retype and remove a
+/// class's members, and the folds that open each member's description and semantic metadata.
+/// </summary>
+/// <remarks>
+/// Its own class rather than another part of <see cref="SchemaEditor"/>. The grid is the largest
+/// panel the editor draws and the only one that reaches into a member's type, so keeping it here
+/// couples the array container, the array key and the member's metadata to the grid that edits
+/// them rather than to the editor as a whole.
+/// </remarks>
+/// <param name="schemaEditor">The editor this panel draws inside, which owns the undo stack.</param>
+internal sealed class MemberGridPanel(SchemaEditor schemaEditor)
+{
+	private MemberSemanticsPanel Semantics { get; } = new(schemaEditor);
+
+	internal static void ShowMemberHeadings()
+	{
+		ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.3f, 0.3f, 0.3f, 1.0f));
+		ImGui.Button("Name", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGui.SameLine();
+		ImGui.Button("Type", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGui.SameLine();
+		ImGui.Button("Container", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGui.SameLine();
+		ImGui.Button("Key", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGui.PopStyleColor();
+	}
+
+	/// <summary>
+	/// Draws a class's members.
+	/// </summary>
+	/// <param name="schema">The schema the class belongs to.</param>
+	/// <param name="schemaClass">The class whose members are being edited.</param>
+	internal void Show(Schema schema, SchemaClass schemaClass)
+	{
+		if (!ImGui.CollapsingHeader($"{schemaClass.Name} Members", ImGuiTreeNodeFlags.DefaultOpen))
+		{
+			return;
+		}
+
+		float frameHeight = ImGui.GetFrameHeight();
+		float spacing = ImGui.GetStyle().ItemSpacing.X;
+
+		// Leave room for the reorder, delete and fold controls that precede each row.
+		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((frameHeight + spacing) * 5));
+		ShowMemberHeadings();
+
+		SchemaMember[] members = [.. schemaClass.Members];
+		for (int index = 0; index < members.Length; index++)
+		{
+			ShowMemberRow(schema, schemaClass, members[index], index, members.Length, frameHeight);
+		}
+
+		ImGui.NewLine();
+	}
+
+	private void ShowMemberRow(Schema schema, SchemaClass schemaClass, SchemaMember member, int index, int memberCount, float frameHeight)
+	{
+		ImGui.PushID($"member{member.Name}");
+
+		// A probe scope alongside the ImGui id stack: PushID keeps two rows' widgets apart for
+		// ImGui, and this keeps their recorded names apart for a test, which would otherwise see
+		// one ambiguous "Delete" however many members the class has.
+		ImGuiProbes.PushScope($"member{member.Name}");
+
+		ShowMemberReorderButtons(schemaClass, member, index, memberCount);
+
+		ImGui.SameLine();
+		bool deleteClicked = ImGui.Button("X", new Vector2(frameHeight, 0));
+		ImGuiProbes.MarkItem("Delete");
+		if (deleteClicked)
+		{
+			DeleteMember(schemaClass, member);
+		}
+
+		ImGui.SameLine();
+		string descriptionKey = $"memberdescription:{schemaClass.Name}.{member.Name}";
+		bool descriptionOpen = !schemaEditor.IsVisible(descriptionKey);
+		bool toggleDescription = ImGui.ArrowButton("##ToggleDescription", descriptionOpen ? ImGuiDir.Down : ImGuiDir.Right);
+		ImGuiProbes.MarkItem("ToggleDescription");
+		if (toggleDescription)
+		{
+			schemaEditor.ToggleVisibility(descriptionKey);
+		}
+
+		if (ImGui.IsItemHovered())
+		{
+			ImGui.SetTooltip(string.IsNullOrEmpty(member.Description) ? "Add a description" : member.Description);
+		}
+
+		ImGui.SameLine();
+		bool semanticsOpen = ShowSemanticsToggle(schemaClass, member, frameHeight);
+
+		ImGui.SameLine();
+		ShowMemberNameField(schemaClass, member);
+
+		ImGui.SameLine();
+		ShowMemberConfig(schema, member);
+
+		ShowMemberIssueMarker(member);
+
+		if (descriptionOpen)
+		{
+			ImGui.Indent();
+			schemaEditor.ShowDescriptionEditor(
+				$"##MemberDescription{schemaClass.Name}.{member.Name}",
+				"Description:",
+				member.Description,
+				value => member.Description = value);
+			ImGui.Unindent();
+		}
+
+		if (semanticsOpen)
+		{
+			Semantics.Show(schema, member);
+		}
+
+		ImGuiProbes.PopScope();
+		ImGui.PopID();
+	}
+
+	/// <summary>
+	/// Draws the control that folds a member's semantic metadata open, and reports whether it is
+	/// open.
+	/// </summary>
+	/// <remarks>
+	/// Labelled by what it holds rather than by a fixed glyph: a member that carries metadata says
+	/// so with a dot while folded, which is the only way a folded row could show it at all. The
+	/// button keeps the delete button's width either way, so a class of members with and without
+	/// metadata still draws as a grid.
+	/// </remarks>
+	private bool ShowSemanticsToggle(SchemaClass schemaClass, SchemaMember member, float frameHeight)
+	{
+		string key = $"membersemantics:{schemaClass.Name}.{member.Name}";
+		bool open = !schemaEditor.IsVisible(key);
+
+		bool clicked = ImGui.Button(MemberSemanticsPanel.HasSemantics(member) ? "*" : "-", new Vector2(frameHeight, 0));
+		ImGuiProbes.MarkItem("ToggleSemantics");
+		if (clicked)
+		{
+			schemaEditor.ToggleVisibility(key);
+			open = !open;
+		}
+
+		if (ImGui.IsItemHovered())
+		{
+			ImGui.SetTooltip(MemberSemanticsPanel.DescribeSemantics(member));
+		}
+
+		return open;
+	}
+
+	/// <summary>
+	/// Draws the up/down controls that move a member within its class.
+	/// </summary>
+	/// <remarks>
+	/// Up/down rather than drag-and-drop: the member row is already five controls wide, and a drag
+	/// source competing with the text field and the type button in that space is easy to trigger
+	/// by accident.
+	/// </remarks>
+	private void ShowMemberReorderButtons(SchemaClass schemaClass, SchemaMember member, int index, int memberCount)
+	{
+		ImGui.BeginDisabled(index == 0);
+		bool moveUp = ImGui.ArrowButton("##MoveUp", ImGuiDir.Up);
+		ImGuiProbes.MarkItem("MoveUp");
+		if (moveUp)
+		{
+			MoveMember(schemaClass, member, index - 1);
+		}
+
+		ImGui.EndDisabled();
+
+		ImGui.SameLine();
+		ImGui.BeginDisabled(index == memberCount - 1);
+		bool moveDown = ImGui.ArrowButton("##MoveDown", ImGuiDir.Down);
+		ImGuiProbes.MarkItem("MoveDown");
+		if (moveDown)
+		{
+			MoveMember(schemaClass, member, index + 1);
+		}
+
+		ImGui.EndDisabled();
+	}
+
+	private void MoveMember(SchemaClass schemaClass, SchemaMember member, int newIndex)
+	{
+		int previousIndex = schemaClass.IndexOfMember(member);
+		if (previousIndex < 0)
+		{
+			return;
+		}
+
+		schemaEditor.Execute(new DelegateCommand(
+			$"Move Member '{member.Name}'",
+			() => schemaClass.TryMoveMember(member, newIndex),
+			() => schemaClass.TryMoveMember(member, previousIndex),
+			ChangeType.Move));
+	}
+
+	private void ShowMemberNameField(SchemaClass schemaClass, SchemaMember member)
+	{
+		if (EditField.Text("##Name", SchemaEditor.FieldWidth, member.Name, out string committed, 64))
+		{
+			schemaEditor.ApplyRename("member", member.Name, committed,
+				newName => schemaClass.TryRenameMember(member, newName.As<MemberName>()));
+		}
+	}
+
+	/// <summary>
+	/// Marks a member row that owns a validation issue, with the message as its tooltip.
+	/// </summary>
+	private void ShowMemberIssueMarker(SchemaMember member)
+	{
+		SchemaValidationIssue? issue = schemaEditor.GetIssueFor(member);
+		if (issue is null)
+		{
+			return;
+		}
+
+		ImGui.SameLine();
+		using (EditorTheme.Severity(issue.Severity))
+		{
+			ImGui.TextUnformatted(issue.Severity == SchemaValidationSeverity.Error ? "!" : "?");
+		}
+
+		if (ImGui.IsItemHovered())
+		{
+			ImGui.SetTooltip(issue.Message);
+		}
+	}
+
+	/// <summary>
+	/// Removes a member, remembering where it was so an undo puts it back there.
+	/// </summary>
+	/// <remarks>
+	/// <c>RestoreMember</c> appends, and member order is part of the schema's meaning rather than
+	/// a display concern - it is the declaration order generated code uses, and it round-trips
+	/// through the file. So restoring alone turns an undo into an edit of its own: delete a member
+	/// from the middle of a class, undo, and the class comes back reordered.
+	/// </remarks>
+	private void DeleteMember(SchemaClass schemaClass, SchemaMember member)
+	{
+		int index = schemaClass.IndexOfMember(member);
+
+		schemaEditor.Execute(new DelegateCommand(
+			$"Delete Member '{member.Name}'",
+			() => member.TryRemove(),
+			() =>
+			{
+				schemaClass.RestoreMember(member);
+				schemaClass.TryMoveMember(member, index);
+			},
+			ChangeType.Delete));
+	}
+
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S3267:Loops should be simplified with \"LINQ\" expressions", Justification = "We want to separate out ImGui calls from enumerations")]
+	internal void ShowMemberConfig(Schema schema, SchemaMember schemaMember)
+	{
+		Ensure.NotNull(schema);
+		Ensure.NotNull(schemaMember);
+
+		bool typeClicked = ImGui.Button($"{schemaMember.Type.DisplayName}##Type", new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGuiProbes.MarkItem("Type");
+		if (typeClicked)
+		{
+			SchemaMember captured = schemaMember;
+			schemaEditor.Popups.OpenTypeList("Select Type", "Type", schema.GetAvailableTypes(), captured.Type, (type) => SetMemberType(captured, type));
+		}
+
+		if (schemaMember.Type is not SchemaTypes.Array array)
+		{
+			return;
+		}
+
+		ImGui.SameLine();
+		if (EditField.Text("##Container", SchemaEditor.FieldWidth, array.Container, out string container, 64))
+		{
+			ContainerName previous = array.Container;
+			ContainerName next = container.As<ContainerName>();
+			schemaEditor.Execute(new DelegateCommand(
+				$"Set Container '{next}'",
+				() => array.Container = next,
+				() => array.Container = previous,
+				ChangeType.Modify));
+		}
+
+		if (array.ElementType is SchemaTypes.Object obj && obj.Class is not null)
+		{
+			ImGui.SameLine();
+			ShowArrayKeySelector(array, obj.Class);
+		}
+	}
+
+	private void SetMemberType(SchemaMember member, SchemaTypes.BaseType type)
+	{
+		SchemaTypes.BaseType previous = member.Type;
+		schemaEditor.Execute(new DelegateCommand(
+			$"Set Type '{type.DisplayName}'",
+			() => member.SetType(type),
+			() => member.SetType(previous),
+			ChangeType.Modify));
+	}
+
+	private void ShowArrayKeySelector(SchemaTypes.Array array, SchemaClass elementClass)
+	{
+		ImGui.Button(string.IsNullOrEmpty(array.Key) ? SchemaEditor.NoneOption : array.Key, new Vector2(SchemaEditor.FieldWidth, 0));
+		ImGuiProbes.MarkItem("KeySelector");
+
+		if (!ImGui.BeginPopupContextItem("##Key", ImGuiPopupFlags.MouseButtonLeft))
+		{
+			return;
+		}
+
+		bool none = ImGui.Selectable(SchemaEditor.NoneOption);
+		ImGuiProbes.MarkItem("key-option", SchemaEditor.NoneOption);
+		if (none)
+		{
+			SetArrayKey(array, new MemberName());
+		}
+
+		foreach (SchemaMember primitiveMember in elementClass.Members.Where(m => m.Type.IsPrimitive).OrderBy(m => m.Name.ToString(), StringComparer.Ordinal))
+		{
+			bool chosen = ImGui.Selectable(primitiveMember.Name);
+			ImGuiProbes.MarkItem("key-option", primitiveMember.Name);
+			if (chosen)
+			{
+				SetArrayKey(array, primitiveMember.Name);
+			}
+		}
+
+		ImGui.EndPopup();
+	}
+
+	private void SetArrayKey(SchemaTypes.Array array, MemberName key)
+	{
+		MemberName previous = array.Key;
+		schemaEditor.Execute(new DelegateCommand(
+			$"Set Array Key '{key}'",
+			() => array.Key = key,
+			() => array.Key = previous,
+			ChangeType.Modify));
+	}
+}

--- a/SchemaEditor/MemberSemanticsPanel.cs
+++ b/SchemaEditor/MemberSemanticsPanel.cs
@@ -1,0 +1,541 @@
+// Copyright (c) 2023-2026 ktsu-dev contributors
+
+namespace ktsu.SchemaEditor;
+
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+
+using Hexa.NET.ImGui;
+
+using ktsu.ImGui.Probes;
+using ktsu.Schema.Models;
+using ktsu.Schema.Models.Metadata;
+using ktsu.Semantics.Quantities;
+using ktsu.Semantics.Strings;
+using ktsu.UndoRedo;
+
+using SchemaTypes = Schema.Models.Types;
+
+/// <summary>
+/// The panel for the semantic metadata a member carries beside its type: what its values are
+/// measured in, the range they may take, the value it starts at, how two of its states blend, how
+/// it goes on the wire, and how an editor should present it.
+/// </summary>
+/// <remarks>
+/// Folded away behind a toggle rather than shown in the member row. The row is already five
+/// controls wide, and all six of these are absent on most members - an identifier measures
+/// nothing, has no range and blends with nothing - so a row that always drew them would spend
+/// most of its width saying "none" six times.
+/// <para>
+/// Its own class rather than another part of <see cref="SchemaEditor"/>, so that the six kinds of
+/// metadata and the unit registry behind them are coupled to the panel that draws them rather than
+/// to the editor as a whole.
+/// </para>
+/// </remarks>
+/// <param name="schemaEditor">The editor this panel draws inside, which owns the undo stack.</param>
+internal sealed class MemberSemanticsPanel(SchemaEditor schemaEditor)
+{
+	private Popups Popups => schemaEditor.Popups;
+
+	private static float FieldWidth => SchemaEditor.FieldWidth;
+	/// <summary>
+	/// The width of the label column inside the metadata panel, in ems, so the controls line up
+	/// under each other whatever the font size.
+	/// </summary>
+	private const float MetadataLabelEms = 7.0f;
+
+	/// <summary>
+	/// What the kind picker calls each kind of default, and the order it offers them in.
+	/// </summary>
+	/// <remarks>
+	/// Names rather than types, because "no default at all" is one of the choices and has no type
+	/// to name it with.
+	/// </remarks>
+	private static readonly string[] DefaultKinds = [SchemaEditor.NoneOption, "Number", "Boolean", "Text"];
+
+	/// <summary>
+	/// Draws the metadata editor for a member, and the controls that set it.
+	/// </summary>
+	/// <param name="schema">The schema the member belongs to, for resolving an enum default.</param>
+	/// <param name="member">The member being edited.</param>
+	internal void Show(Schema schema, SchemaMember member)
+	{
+		ImGui.Indent();
+
+		ShowUnitField(member);
+		ShowRangeFields(member);
+		ShowDefaultFields(schema, member);
+		ShowInterpolationField(member);
+		ShowNetworkFields(member);
+		ShowEditorHintField(member);
+
+		ImGui.Unindent();
+	}
+
+	/// <summary>
+	/// Whether a member carries any metadata at all, which is what the folded row reports.
+	/// </summary>
+	/// <param name="member">The member to ask about.</param>
+	/// <returns>True when at least one of the six properties is set.</returns>
+	internal static bool HasSemantics(SchemaMember member)
+	{
+		Ensure.NotNull(member);
+
+		return member.Unit is not null
+			|| member.Range is not null
+			|| member.DefaultValue is not null
+			|| member.Network is not null
+			|| member.Editor is not null
+			|| member.Interpolation is not Interpolation.None;
+	}
+
+	/// <summary>
+	/// Draws a label and leaves the cursor where the row's first control goes.
+	/// </summary>
+	private static void ShowMetadataLabel(string label)
+	{
+		float column = ImGui.GetFontSize() * MetadataLabelEms;
+		float start = ImGui.GetCursorPosX();
+		ImGui.TextUnformatted(label);
+		ImGui.SameLine();
+		ImGui.SetCursorPosX(start + column);
+	}
+
+	/// <summary>
+	/// Draws the unit picker.
+	/// </summary>
+	/// <remarks>
+	/// A picker over the registry rather than a text field, because a unit typed by hand is only
+	/// discovered to be wrong when the schema is next validated, and the registry is the thing
+	/// that knows which spellings exist.
+	/// </remarks>
+	private void ShowUnitField(SchemaMember member)
+	{
+		ShowMetadataLabel("Unit:");
+
+		bool clicked = ImGui.Button(member.Unit is null ? SchemaEditor.NoneOption : member.Unit.ToString(), new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("Unit");
+
+		if (member.Unit is not null && ImGui.IsItemHovered())
+		{
+			ImGui.SetTooltip(UnitRegistry.TryResolve(member.Unit, out IUnit? resolved, out string error)
+				? $"{resolved!.Name} ({resolved.Symbol})"
+				: error);
+		}
+
+		if (clicked)
+		{
+			SchemaMember captured = member;
+			Popups.OpenUnitList("Select Unit", "Unit", UnitRegistry.All, captured.Unit, unit => SetUnit(captured, unit));
+		}
+	}
+
+	/// <summary>
+	/// Applies a chosen unit, or clears it.
+	/// </summary>
+	/// <remarks>
+	/// What is written is <see cref="UnitRegistry.PreferredText"/> rather than the symbol, so the
+	/// two units whose symbols are shared are written by name and the file always resolves back to
+	/// the unit that was actually picked.
+	/// </remarks>
+	private void SetUnit(SchemaMember member, IUnit? unit)
+	{
+		UnitSymbol? previous = member.Unit;
+		UnitSymbol? next = unit is null ? null : UnitRegistry.PreferredText(unit).As<UnitSymbol>();
+
+		schemaEditor.Execute(new DelegateCommand(
+			unit is null ? "Clear Unit" : $"Set Unit '{next}'",
+			() => member.Unit = next,
+			() => member.Unit = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Draws the range: whether the member has one, its bounds, and whether it wraps.
+	/// </summary>
+	private void ShowRangeFields(SchemaMember member)
+	{
+		ShowMetadataLabel("Range:");
+
+		bool bounded = member.Range is not null;
+		if (ImGui.Checkbox("##Bounded", ref bounded))
+		{
+			SetRange(member, bounded ? new MemberRange() : null, bounded ? "Add Range" : "Remove Range");
+		}
+
+		ImGuiProbes.MarkItem("Bounded");
+
+		if (member.Range is not MemberRange range)
+		{
+			return;
+		}
+
+		ImGui.SameLine();
+		if (EditField.Number("##RangeMinimum", FieldWidth * 0.5f, range.Minimum, out double minimum))
+		{
+			SetRange(member, new MemberRange { Minimum = minimum, Maximum = range.Maximum, Wrap = range.Wrap }, "Set Range Minimum");
+		}
+
+		ImGui.SameLine();
+		if (EditField.Number("##RangeMaximum", FieldWidth * 0.5f, range.Maximum, out double maximum))
+		{
+			SetRange(member, new MemberRange { Minimum = range.Minimum, Maximum = maximum, Wrap = range.Wrap }, "Set Range Maximum");
+		}
+
+		ImGui.SameLine();
+		ImGui.TextUnformatted("wrap");
+		ImGui.SameLine();
+
+		// A hidden label, like every other control here: a checkbox's visible label sits inside the
+		// item's rectangle without being clickable, so a caption here would leave the middle of
+		// the control - where a test aims - hitting nothing.
+		bool wrap = range.Wrap;
+		if (ImGui.Checkbox("##Wrap", ref wrap))
+		{
+			SetRange(member, new MemberRange { Minimum = range.Minimum, Maximum = range.Maximum, Wrap = wrap }, wrap ? "Wrap Range" : "Unwrap Range");
+		}
+
+		ImGuiProbes.MarkItem("Wrap");
+
+		if (ImGui.IsItemHovered())
+		{
+			// The one thing about a range that is easy to read backwards, so it is said where the
+			// question is asked rather than only in the format documentation.
+			ImGui.SetTooltip("A wrapping range is a period rather than a bound: a value outside it is un-normalised, not invalid.");
+		}
+	}
+
+	/// <summary>
+	/// Replaces a member's range, recording one undo entry.
+	/// </summary>
+	/// <remarks>
+	/// A range is immutable, so every edit to one is a replacement. That is what makes an undo of
+	/// a bound a single assignment rather than a field-by-field restoration.
+	/// </remarks>
+	private void SetRange(SchemaMember member, MemberRange? next, string description)
+	{
+		MemberRange? previous = member.Range;
+		schemaEditor.Execute(new DelegateCommand(
+			description,
+			() => member.Range = next,
+			() => member.Range = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Draws the default: which kind of value it is, and the value itself.
+	/// </summary>
+	private void ShowDefaultFields(Schema schema, SchemaMember member)
+	{
+		ShowMetadataLabel("Default:");
+
+		string kind = member.DefaultValue switch
+		{
+			NumberDefault => "Number",
+			BooleanDefault => "Boolean",
+			TextDefault => "Text",
+			_ => SchemaEditor.NoneOption,
+		};
+
+		ImGui.Button(kind, new Vector2(FieldWidth * 0.6f, 0));
+		ImGuiProbes.MarkItem("DefaultKind");
+		ShowDefaultKindMenu(member);
+
+		switch (member.DefaultValue)
+		{
+			case NumberDefault number:
+				ImGui.SameLine();
+				if (EditField.Number("##DefaultNumber", FieldWidth * 0.5f, number.Value, out double committed))
+				{
+					SetDefault(member, new NumberDefault { Value = committed }, "Set Default");
+				}
+
+				return;
+
+			case BooleanDefault boolean:
+				ImGui.SameLine();
+				bool value = boolean.Value;
+				if (ImGui.Checkbox("##DefaultBoolean", ref value))
+				{
+					SetDefault(member, new BooleanDefault { Value = value }, "Set Default");
+				}
+
+				ImGuiProbes.MarkItem("DefaultBoolean");
+				return;
+
+			case TextDefault text:
+				ImGui.SameLine();
+				ShowTextDefault(schema, member, text);
+				return;
+
+			default:
+				return;
+		}
+	}
+
+	/// <summary>
+	/// Offers the kinds of default a member can have.
+	/// </summary>
+	private void ShowDefaultKindMenu(SchemaMember member)
+	{
+		if (!ImGui.BeginPopupContextItem("##DefaultKind", ImGuiPopupFlags.MouseButtonLeft))
+		{
+			return;
+		}
+
+		foreach (string kind in DefaultKinds)
+		{
+			bool chosen = ImGui.Selectable(kind);
+			ImGuiProbes.MarkItem("default-kind-option", kind);
+			if (chosen)
+			{
+				SetDefault(member, NewDefault(kind), kind == SchemaEditor.NoneOption ? "Remove Default" : $"Set Default Kind '{kind}'");
+			}
+		}
+
+		ImGui.EndPopup();
+	}
+
+	/// <summary>
+	/// Builds an empty default of the chosen kind.
+	/// </summary>
+	/// <remarks>
+	/// Zero, false and the empty string: the kind is what the user asked for, and the value is the
+	/// next thing they will type. A default is not the same as a zeroed value, but zero is the
+	/// least surprising thing to offer while the field is still being filled in.
+	/// </remarks>
+	private static MemberDefault? NewDefault(string kind) => kind switch
+	{
+		"Number" => new NumberDefault(),
+		"Boolean" => new BooleanDefault(),
+		"Text" => new TextDefault(),
+		_ => null,
+	};
+
+	/// <summary>
+	/// Draws the value of a textual default: a picker of the enum's values on an enum member, and
+	/// a text field on anything else.
+	/// </summary>
+	/// <remarks>
+	/// A picker on an enum member because a name that is not one of the enum's values is the
+	/// mistake this default invites, and the schema already knows which names are allowed.
+	/// </remarks>
+	private void ShowTextDefault(Schema schema, SchemaMember member, TextDefault text)
+	{
+		if (member.Type is not SchemaTypes.Enum enumType || !schema.TryGetEnum(enumType.EnumName, out SchemaEnum? target) || target is null)
+		{
+			if (EditField.Text("##DefaultText", FieldWidth, text.Value, out string committed))
+			{
+				SetDefault(member, new TextDefault { Value = committed }, "Set Default");
+			}
+
+			return;
+		}
+
+		ImGui.Button(string.IsNullOrEmpty(text.Value) ? SchemaEditor.NoneOption : text.Value, new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("DefaultEnumValue");
+
+		if (!ImGui.BeginPopupContextItem("##DefaultEnumValue", ImGuiPopupFlags.MouseButtonLeft))
+		{
+			return;
+		}
+
+		foreach (string value in target.Values.Select(value => value.ToString()))
+		{
+			bool chosen = ImGui.Selectable(value);
+			ImGuiProbes.MarkItem("enum-default-option", value);
+			if (chosen)
+			{
+				SetDefault(member, new TextDefault { Value = value }, $"Set Default '{value}'");
+			}
+		}
+
+		ImGui.EndPopup();
+	}
+
+	/// <summary>
+	/// Replaces a member's default, recording one undo entry.
+	/// </summary>
+	private void SetDefault(SchemaMember member, MemberDefault? next, string description)
+	{
+		MemberDefault? previous = member.DefaultValue;
+		schemaEditor.Execute(new DelegateCommand(
+			description,
+			() => member.DefaultValue = next,
+			() => member.DefaultValue = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Draws the interpolation picker.
+	/// </summary>
+	private void ShowInterpolationField(SchemaMember member)
+	{
+		ShowMetadataLabel("Blends:");
+
+		ImGui.Button(member.Interpolation.ToString(), new Vector2(FieldWidth, 0));
+		ImGuiProbes.MarkItem("Interpolation");
+
+		if (!ImGui.BeginPopupContextItem("##Interpolation", ImGuiPopupFlags.MouseButtonLeft))
+		{
+			return;
+		}
+
+		foreach (Interpolation mode in System.Enum.GetValues<Interpolation>())
+		{
+			bool chosen = ImGui.Selectable(mode.ToString());
+			ImGuiProbes.MarkItem("interpolation-option", mode.ToString());
+			if (chosen)
+			{
+				SetInterpolation(member, mode);
+			}
+		}
+
+		ImGui.EndPopup();
+	}
+
+	private void SetInterpolation(SchemaMember member, Interpolation mode)
+	{
+		Interpolation previous = member.Interpolation;
+		schemaEditor.Execute(new DelegateCommand(
+			$"Set Interpolation '{mode}'",
+			() => member.Interpolation = mode,
+			() => member.Interpolation = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Draws the network encoding: whether the member carries any guidance, its quantisation step
+	/// and whether it is sent as a delta.
+	/// </summary>
+	private void ShowNetworkFields(SchemaMember member)
+	{
+		ShowMetadataLabel("Network:");
+
+		bool encoded = member.Network is not null;
+		if (ImGui.Checkbox("##Encoded", ref encoded))
+		{
+			SetNetwork(member, encoded ? new MemberNetwork() : null, encoded ? "Add Network Encoding" : "Remove Network Encoding");
+		}
+
+		ImGuiProbes.MarkItem("Encoded");
+
+		if (member.Network is not MemberNetwork network)
+		{
+			return;
+		}
+
+		ImGui.SameLine();
+		ImGui.TextUnformatted("step");
+		ImGui.SameLine();
+		if (EditField.Number("##Quantise", FieldWidth * 0.5f, network.Quantise, out double quantise))
+		{
+			SetNetwork(member, new MemberNetwork { Quantise = quantise, Delta = network.Delta }, "Set Quantisation Step");
+		}
+
+		if (ImGui.IsItemHovered())
+		{
+			ImGui.SetTooltip("The smallest change worth transmitting, in the member's own unit. Zero sends full precision.");
+		}
+
+		ImGui.SameLine();
+		ImGui.TextUnformatted("delta");
+		ImGui.SameLine();
+		bool delta = network.Delta;
+		if (ImGui.Checkbox("##Delta", ref delta))
+		{
+			SetNetwork(member, new MemberNetwork { Quantise = network.Quantise, Delta = delta }, delta ? "Send As Delta" : "Send In Full");
+		}
+
+		ImGuiProbes.MarkItem("Delta");
+	}
+
+	/// <summary>
+	/// Replaces a member's network encoding, recording one undo entry.
+	/// </summary>
+	private void SetNetwork(SchemaMember member, MemberNetwork? next, string description)
+	{
+		MemberNetwork? previous = member.Network;
+		schemaEditor.Execute(new DelegateCommand(
+			description,
+			() => member.Network = next,
+			() => member.Network = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Draws the editor hint, which is free text because the set of useful controls is open.
+	/// </summary>
+	private void ShowEditorHintField(SchemaMember member)
+	{
+		ShowMetadataLabel("Editor:");
+
+		string current = member.Editor?.ToString() ?? string.Empty;
+		if (!EditField.Text("##EditorHint", FieldWidth, current, out string committed))
+		{
+			return;
+		}
+
+		EditorHint? previous = member.Editor;
+
+		// Empty means no hint rather than an empty one, so clearing the field removes the property
+		// from the file instead of writing "" into it.
+		EditorHint? next = string.IsNullOrWhiteSpace(committed) ? null : committed.As<EditorHint>();
+
+		schemaEditor.Execute(new DelegateCommand(
+			next is null ? "Clear Editor Hint" : $"Set Editor Hint '{next}'",
+			() => member.Editor = next,
+			() => member.Editor = previous,
+			ChangeType.Modify));
+	}
+
+	/// <summary>
+	/// Summarises a member's metadata for the folded row's tooltip.
+	/// </summary>
+	/// <param name="member">The member to describe.</param>
+	/// <returns>A one-line summary, or an invitation to add some when there is none.</returns>
+	internal static string DescribeSemantics(SchemaMember member)
+	{
+		Ensure.NotNull(member);
+
+		if (!HasSemantics(member))
+		{
+			return "No unit, range, default, interpolation or network encoding.";
+		}
+
+		List<string> parts = [];
+
+		if (member.Unit is not null)
+		{
+			parts.Add($"in {member.Unit}");
+		}
+
+		if (member.Range is not null)
+		{
+			parts.Add(member.Range.ToString());
+		}
+
+		if (member.DefaultValue is not null)
+		{
+			parts.Add($"defaults to {member.DefaultValue}");
+		}
+
+		if (member.Interpolation is not Interpolation.None)
+		{
+			parts.Add(member.Interpolation.ToString().ToLower(CultureInfo.InvariantCulture));
+		}
+
+		if (member.Network is not null)
+		{
+			parts.Add(member.Network.ToString());
+		}
+
+		if (member.Editor is not null)
+		{
+			parts.Add($"shown as {member.Editor}");
+		}
+
+		return string.Join(", ", parts);
+	}
+}

--- a/SchemaEditor/Popups.cs
+++ b/SchemaEditor/Popups.cs
@@ -9,7 +9,9 @@ using System.Text.Json.Serialization;
 using static ktsu.ImGui.Popups.ImGuiPopups;
 using ktsu.Semantics.Paths;
 
+using ktsu.Schema.Models.Metadata;
 using ktsu.Schema.Models.Types;
+using ktsu.Semantics.Quantities;
 
 internal sealed class Popups
 {
@@ -17,6 +19,7 @@ internal sealed class Popups
 	[JsonIgnore] private Prompt PopupPrompt { get; init; } = new();
 	[JsonIgnore] private InputString PopupInputString { get; init; } = new();
 	[JsonIgnore] private SearchableList<BaseType> PopupTypeList { get; init; } = new();
+	[JsonIgnore] private SearchableList<IUnit> PopupUnitList { get; init; } = new();
 	[JsonInclude] private FilesystemBrowser PopupFilesystemBrowser { get; init; } = new();
 	[JsonIgnore] private Queue<Action> Queue { get; init; } = [];
 
@@ -67,6 +70,33 @@ internal sealed class Popups
 			PopupTypeList.Open(title, label, types, selected, (t) => t.DisplayName, onConfirm);
 		});
 
+	/// <summary>
+	/// Opens the unit picker, with the unit the member already names selected.
+	/// </summary>
+	/// <remarks>
+	/// Searchable rather than a menu because the registry holds close to two hundred units, which
+	/// is more than a list is worth scrolling. Each is offered as its name and its symbol
+	/// together: the symbol is what a schema usually writes, and the name is what tells two units
+	/// sharing a symbol apart.
+	/// <para>
+	/// The member's unit is text and may be either spelling, or something that resolves to no unit
+	/// at all, so the selection is resolved through <see cref="UnitRegistry"/> rather than matched
+	/// on the text.
+	/// </para>
+	/// </remarks>
+	/// <param name="title">The popup title.</param>
+	/// <param name="label">The label above the list.</param>
+	/// <param name="units">The units that can be chosen from.</param>
+	/// <param name="current">The unit text the member holds now, or null when it has none.</param>
+	/// <param name="onConfirm">Applies the chosen unit. Null clears the member's unit.</param>
+	internal void OpenUnitList(string title, string label, IEnumerable<IUnit> units, UnitSymbol? current, Action<IUnit?> onConfirm) =>
+		Queue.Enqueue(() =>
+		{
+			List<IUnit> choices = [.. units];
+			IUnit? selected = UnitRegistry.TryResolve(current, out IUnit? resolved, out _) ? resolved : null;
+			PopupUnitList.Open(title, label, choices, selected, unit => $"{unit.Name} ({unit.Symbol})", onConfirm!);
+		});
+
 	internal void Update()
 	{
 		while (Queue.Count > 0)
@@ -76,6 +106,7 @@ internal sealed class Popups
 		}
 
 		PopupTypeList.ShowIfOpen();
+		PopupUnitList.ShowIfOpen();
 		PopupMessageOK.ShowIfOpen();
 		PopupPrompt.ShowIfOpen();
 		PopupInputString.ShowIfOpen();

--- a/SchemaEditor/SchemaEditor.Panels.cs
+++ b/SchemaEditor/SchemaEditor.Panels.cs
@@ -4,7 +4,6 @@
 
 namespace ktsu.SchemaEditor;
 
-using System.Linq;
 using System.Numerics;
 
 using Hexa.NET.ImGui;
@@ -16,8 +15,6 @@ using ktsu.Semantics.Paths;
 using ktsu.Semantics.Strings;
 using ktsu.UndoRedo;
 
-using SchemaTypes = Schema.Models.Types;
-
 /// <summary>
 /// The property panels for the selected schema element, and the member grid.
 /// </summary>
@@ -28,7 +25,7 @@ public partial class SchemaEditor
 	/// <summary>
 	/// What a picker offers for "point this at nothing", and the name that option is recorded under.
 	/// </summary>
-	private const string NoneOption = "<none>";
+	internal const string NoneOption = "<none>";
 
 	/// <summary>
 	/// Draws a description editor bound to a schema element, committing one undo entry per edit.
@@ -130,7 +127,7 @@ public partial class SchemaEditor
 			ShowDescriptionEditor($"##ClassDescription{schemaClass.Name}", "Description:", schemaClass.Description, value => schemaClass.Description = value);
 		}
 
-		ShowMembers();
+		MemberGrid.Show(schema, schemaClass);
 	}
 
 	private void ShowEnumProperties()
@@ -236,296 +233,6 @@ public partial class SchemaEditor
 			$"Set Data Source Class '{className}'",
 			() => dataSource.ClassName = className,
 			() => dataSource.ClassName = previous,
-			ChangeType.Modify));
-	}
-
-	public static void ShowMemberHeadings()
-	{
-		ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.3f, 0.3f, 0.3f, 1.0f));
-		ImGui.Button("Name", new Vector2(FieldWidth, 0));
-		ImGui.SameLine();
-		ImGui.Button("Type", new Vector2(FieldWidth, 0));
-		ImGui.SameLine();
-		ImGui.Button("Container", new Vector2(FieldWidth, 0));
-		ImGui.SameLine();
-		ImGui.Button("Key", new Vector2(FieldWidth, 0));
-		ImGui.PopStyleColor();
-	}
-
-	private void ShowMembers()
-	{
-		if (CurrentClass is null || CurrentSchema is null)
-		{
-			return;
-		}
-
-		SchemaClass schemaClass = CurrentClass;
-		if (!ImGui.CollapsingHeader($"{schemaClass.Name} Members", ImGuiTreeNodeFlags.DefaultOpen))
-		{
-			return;
-		}
-
-		float frameHeight = ImGui.GetFrameHeight();
-		float spacing = ImGui.GetStyle().ItemSpacing.X;
-
-		// Leave room for the reorder and delete controls that precede each row.
-		ImGui.SetCursorPosX(ImGui.GetCursorPosX() + ((frameHeight + spacing) * 4));
-		ShowMemberHeadings();
-
-		SchemaMember[] members = [.. schemaClass.Members];
-		for (int index = 0; index < members.Length; index++)
-		{
-			ShowMemberRow(schemaClass, members[index], index, members.Length, frameHeight);
-		}
-
-		ImGui.NewLine();
-	}
-
-	private void ShowMemberRow(SchemaClass schemaClass, SchemaMember member, int index, int memberCount, float frameHeight)
-	{
-		ImGui.PushID($"member{member.Name}");
-
-		// A probe scope alongside the ImGui id stack: PushID keeps two rows' widgets apart for
-		// ImGui, and this keeps their recorded names apart for a test, which would otherwise see
-		// one ambiguous "Delete" however many members the class has.
-		ImGuiProbes.PushScope($"member{member.Name}");
-
-		ShowMemberReorderButtons(schemaClass, member, index, memberCount);
-
-		ImGui.SameLine();
-		bool deleteClicked = ImGui.Button("X", new Vector2(frameHeight, 0));
-		ImGuiProbes.MarkItem("Delete");
-		if (deleteClicked)
-		{
-			DeleteMember(schemaClass, member);
-		}
-
-		ImGui.SameLine();
-		string descriptionKey = $"memberdescription:{schemaClass.Name}.{member.Name}";
-		bool descriptionOpen = !IsVisible(descriptionKey);
-		bool toggleDescription = ImGui.ArrowButton("##ToggleDescription", descriptionOpen ? ImGuiDir.Down : ImGuiDir.Right);
-		ImGuiProbes.MarkItem("ToggleDescription");
-		if (toggleDescription)
-		{
-			ToggleVisibility(descriptionKey);
-		}
-
-		if (ImGui.IsItemHovered())
-		{
-			ImGui.SetTooltip(string.IsNullOrEmpty(member.Description) ? "Add a description" : member.Description);
-		}
-
-		ImGui.SameLine();
-		ShowMemberNameField(schemaClass, member);
-
-		ImGui.SameLine();
-		ShowMemberConfig(CurrentSchema!, member);
-
-		ShowMemberIssueMarker(member);
-
-		if (descriptionOpen)
-		{
-			ImGui.Indent();
-			ShowDescriptionEditor(
-				$"##MemberDescription{schemaClass.Name}.{member.Name}",
-				"Description:",
-				member.Description,
-				value => member.Description = value);
-			ImGui.Unindent();
-		}
-
-		ImGuiProbes.PopScope();
-		ImGui.PopID();
-	}
-
-	/// <summary>
-	/// Draws the up/down controls that move a member within its class.
-	/// </summary>
-	/// <remarks>
-	/// Up/down rather than drag-and-drop: the member row is already five controls wide, and a drag
-	/// source competing with the text field and the type button in that space is easy to trigger
-	/// by accident.
-	/// </remarks>
-	private void ShowMemberReorderButtons(SchemaClass schemaClass, SchemaMember member, int index, int memberCount)
-	{
-		ImGui.BeginDisabled(index == 0);
-		bool moveUp = ImGui.ArrowButton("##MoveUp", ImGuiDir.Up);
-		ImGuiProbes.MarkItem("MoveUp");
-		if (moveUp)
-		{
-			MoveMember(schemaClass, member, index - 1);
-		}
-
-		ImGui.EndDisabled();
-
-		ImGui.SameLine();
-		ImGui.BeginDisabled(index == memberCount - 1);
-		bool moveDown = ImGui.ArrowButton("##MoveDown", ImGuiDir.Down);
-		ImGuiProbes.MarkItem("MoveDown");
-		if (moveDown)
-		{
-			MoveMember(schemaClass, member, index + 1);
-		}
-
-		ImGui.EndDisabled();
-	}
-
-	private void MoveMember(SchemaClass schemaClass, SchemaMember member, int newIndex)
-	{
-		int previousIndex = schemaClass.IndexOfMember(member);
-		if (previousIndex < 0)
-		{
-			return;
-		}
-
-		Execute(new DelegateCommand(
-			$"Move Member '{member.Name}'",
-			() => schemaClass.TryMoveMember(member, newIndex),
-			() => schemaClass.TryMoveMember(member, previousIndex),
-			ChangeType.Move));
-	}
-
-	private void ShowMemberNameField(SchemaClass schemaClass, SchemaMember member)
-	{
-		if (EditField.Text("##Name", FieldWidth, member.Name, out string committed, 64))
-		{
-			ApplyRename("member", member.Name, committed,
-				newName => schemaClass.TryRenameMember(member, newName.As<MemberName>()));
-		}
-	}
-
-	/// <summary>
-	/// Marks a member row that owns a validation issue, with the message as its tooltip.
-	/// </summary>
-	private void ShowMemberIssueMarker(SchemaMember member)
-	{
-		SchemaValidationIssue? issue = GetIssueFor(member);
-		if (issue is null)
-		{
-			return;
-		}
-
-		ImGui.SameLine();
-		using (EditorTheme.Severity(issue.Severity))
-		{
-			ImGui.TextUnformatted(issue.Severity == SchemaValidationSeverity.Error ? "!" : "?");
-		}
-
-		if (ImGui.IsItemHovered())
-		{
-			ImGui.SetTooltip(issue.Message);
-		}
-	}
-
-	/// <summary>
-	/// Removes a member, remembering where it was so an undo puts it back there.
-	/// </summary>
-	/// <remarks>
-	/// <c>RestoreMember</c> appends, and member order is part of the schema's meaning rather than
-	/// a display concern - it is the declaration order generated code uses, and it round-trips
-	/// through the file. So restoring alone turns an undo into an edit of its own: delete a member
-	/// from the middle of a class, undo, and the class comes back reordered.
-	/// </remarks>
-	private void DeleteMember(SchemaClass schemaClass, SchemaMember member)
-	{
-		int index = schemaClass.IndexOfMember(member);
-
-		Execute(new DelegateCommand(
-			$"Delete Member '{member.Name}'",
-			() => member.TryRemove(),
-			() =>
-			{
-				schemaClass.RestoreMember(member);
-				schemaClass.TryMoveMember(member, index);
-			},
-			ChangeType.Delete));
-	}
-
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S3267:Loops should be simplified with \"LINQ\" expressions", Justification = "We want to separate out ImGui calls from enumerations")]
-	public void ShowMemberConfig(Schema schema, SchemaMember schemaMember)
-	{
-		Ensure.NotNull(schema);
-		Ensure.NotNull(schemaMember);
-
-		bool typeClicked = ImGui.Button($"{schemaMember.Type.DisplayName}##Type", new Vector2(FieldWidth, 0));
-		ImGuiProbes.MarkItem("Type");
-		if (typeClicked)
-		{
-			SchemaMember captured = schemaMember;
-			Popups.OpenTypeList("Select Type", "Type", schema.GetAvailableTypes(), captured.Type, (type) => SetMemberType(captured, type));
-		}
-
-		if (schemaMember.Type is not SchemaTypes.Array array)
-		{
-			return;
-		}
-
-		ImGui.SameLine();
-		if (EditField.Text("##Container", FieldWidth, array.Container, out string container, 64))
-		{
-			ContainerName previous = array.Container;
-			ContainerName next = container.As<ContainerName>();
-			Execute(new DelegateCommand(
-				$"Set Container '{next}'",
-				() => array.Container = next,
-				() => array.Container = previous,
-				ChangeType.Modify));
-		}
-
-		if (array.ElementType is SchemaTypes.Object obj && obj.Class is not null)
-		{
-			ImGui.SameLine();
-			ShowArrayKeySelector(array, obj.Class);
-		}
-	}
-
-	private void SetMemberType(SchemaMember member, SchemaTypes.BaseType type)
-	{
-		SchemaTypes.BaseType previous = member.Type;
-		Execute(new DelegateCommand(
-			$"Set Type '{type.DisplayName}'",
-			() => member.SetType(type),
-			() => member.SetType(previous),
-			ChangeType.Modify));
-	}
-
-	private void ShowArrayKeySelector(SchemaTypes.Array array, SchemaClass elementClass)
-	{
-		ImGui.Button(string.IsNullOrEmpty(array.Key) ? NoneOption : array.Key, new Vector2(FieldWidth, 0));
-		ImGuiProbes.MarkItem("KeySelector");
-
-		if (!ImGui.BeginPopupContextItem("##Key", ImGuiPopupFlags.MouseButtonLeft))
-		{
-			return;
-		}
-
-		bool none = ImGui.Selectable(NoneOption);
-		ImGuiProbes.MarkItem("key-option", NoneOption);
-		if (none)
-		{
-			SetArrayKey(array, new MemberName());
-		}
-
-		foreach (SchemaMember primitiveMember in elementClass.Members.Where(m => m.Type.IsPrimitive).OrderBy(m => m.Name.ToString(), StringComparer.Ordinal))
-		{
-			bool chosen = ImGui.Selectable(primitiveMember.Name);
-			ImGuiProbes.MarkItem("key-option", primitiveMember.Name);
-			if (chosen)
-			{
-				SetArrayKey(array, primitiveMember.Name);
-			}
-		}
-
-		ImGui.EndPopup();
-	}
-
-	private void SetArrayKey(SchemaTypes.Array array, MemberName key)
-	{
-		MemberName previous = array.Key;
-		Execute(new DelegateCommand(
-			$"Set Array Key '{key}'",
-			() => array.Key = key,
-			() => array.Key = previous,
 			ChangeType.Modify));
 	}
 }

--- a/SchemaEditor/SchemaEditor.cs
+++ b/SchemaEditor/SchemaEditor.cs
@@ -40,6 +40,8 @@ public partial class SchemaEditor
 	internal Popups Popups { get; }
 	private TreeSchema TreeSchema { get; init; }
 	private CodeGeneratorPanel CodeGeneratorPanel { get; init; }
+
+	private MemberGridPanel MemberGrid { get; init; }
 	private ClassGraphView ClassGraph { get; } = new();
 	private ImGuiWidgets.TabPanel MainTabs { get; }
 
@@ -54,6 +56,7 @@ public partial class SchemaEditor
 		UndoRedo = new UndoRedoService(new StackManager(), new SaveBoundaryManager(), new CommandMerger());
 		TreeSchema = new(this);
 		CodeGeneratorPanel = new(this);
+		MemberGrid = new(this);
 		DividerContainerCols =
 			new(
 				"RootDivider",

--- a/SchemaEditor/SchemaEditor.csproj
+++ b/SchemaEditor/SchemaEditor.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="ktsu.IntervalAction" />
     <PackageReference Include="ktsu.Keybinding.Core" />
     <PackageReference Include="ktsu.Semantics.Paths" />
+    <PackageReference Include="ktsu.Semantics.Quantities" />
     <PackageReference Include="ktsu.ThemeProvider" />
     <PackageReference Include="ktsu.Semantics.Strings" />
     <PackageReference Include="ktsu.UndoRedo.Core" />

--- a/docs/schema-format.md
+++ b/docs/schema-format.md
@@ -420,9 +420,35 @@ generating C# from a schema and reimporting the compiled result reproduces the s
 from. A test compiles the generated source and reimports it, so the two mappings cannot drift
 apart unnoticed.
 
-One thing needs help to survive that trip: a `Dictionary<TKey, T>` records the key's *type* but
-not which member it came from. Generated properties for keyed maps therefore carry
-`[ktsu.Schema.Runtime.SchemaKey("Id")]`, which the importer reads back.
+Some things need help to survive that trip, because a C# type says what a value *is* and nothing
+about what it means. A `Dictionary<TKey, T>` records the key's *type* but not which member it came
+from, and a `float` measured in metres per second is the same `float` as one measured in nothing.
+Generated properties therefore carry attributes from `ktsu.Schema.Runtime`, which the importer
+reads back:
+
+| Attribute | Carries |
+| --- | --- |
+| `[SchemaKey("Id")]` | The member a keyed map keys on. |
+| `[SchemaUnit("m/s")]` | The member's unit, in the same spelling the file holds. |
+| `[SchemaRange(0D, 6.2831853D, Wrap = true)]` | Its bounds, and whether they wrap. |
+| `[SchemaDefault(1.5D)]` | Its default. One constructor per kind of value - number, boolean, text - so the overload says which kind it is. |
+| `[SchemaInterpolation(Interpolation.Spherical)]` | How two of its states blend. |
+| `[SchemaNetwork(0.01D, true)]` | Its quantisation step and delta flag. |
+| `[SchemaEditorHint("dial")]` | How an editor should present it. |
+
+A default is also emitted as the property's initialiser, so a generated instance *starts* at the
+default rather than only recording what it should have been:
+
+```csharp
+[ktsu.Schema.Runtime.SchemaUnit("m/s")]
+[ktsu.Schema.Runtime.SchemaRange(0D, 6.2831853D, Wrap = true)]
+[ktsu.Schema.Runtime.SchemaDefault(1.5D)]
+[ktsu.Schema.Runtime.SchemaEditorHint("dial")]
+public float Ratio { get; set; } = 1.5f;
+```
+
+The attribute and the initialiser are not redundant: the initialiser is what makes the object
+right, and the attribute is what lets the default be read back off the type.
 
 ### Running a generator
 

--- a/docs/schema-format.md
+++ b/docs/schema-format.md
@@ -67,6 +67,80 @@ will declare members in.
 | `type` | [type](#types) | The member's type. |
 | `name` | string | The member name. Unique within its class. |
 | `description` | string | Free text. |
+| `unit` | string | The unit the member's values are measured in. See [Units](#units). |
+| `range` | [range](#range) | The values the member may take. |
+| `defaultValue` | [default](#default) | The value the member takes when none is supplied. |
+| `interpolation` | string | `None`, `Linear`, `Spherical` or `Step`. Absent means `None`. |
+| `network` | [network](#network) | How the member should be encoded when sent to a peer. |
+| `editor` | string | A hint about how an editor should present the member. Free text. |
+
+All six are optional and omitted when absent. They were added in format version 2.
+
+### Units
+
+A unit is written as its symbol (`"m/s"`) or its name (`"MeterPerSecond"`), and is resolved
+against the unit registry in `ktsu.Semantics.Quantities` when the schema is validated.
+
+The symbol is the natural thing to write, and is what a person reads. Names exist because two
+symbols in the registry are ambiguous — `g` is both gram and standard gravity, and `rad` is both
+radian and *radiation absorbed dose*, which is not even the same dimension. Validation refuses an
+ambiguous symbol and names the candidates rather than picking one, so a schema that means radians
+must say `"Radian"`.
+
+The text is what the file stores, not a resolved unit: the file stays readable, and the
+conversion factors stay owned by `ktsu.Semantics.Quantities` instead of being copied into every
+schema that uses them.
+
+A unit is only meaningful on a numeric or vector member.
+
+### Range
+
+```json
+{ "minimum": 0.0, "maximum": 6.2831853, "wrap": true }
+```
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `minimum` | number | The smallest allowed value, in the member's own unit. |
+| `maximum` | number | The largest allowed value, in the member's own unit. |
+| `wrap` | boolean | Whether values outside the range wrap into it rather than being invalid. |
+
+`wrap` changes what the range *means*. Without it the range is a bound and a value outside it is
+invalid. With it the range is a **period**: an angle of 7 radians on a `[0, 2π)` member is
+un-normalised rather than wrong, and clamping it to the maximum would be the one transformation
+that is certainly incorrect. A validator should reduce a wrapping value into range and reject a
+non-wrapping one — and for the same reason, a default outside a wrapping range is accepted.
+
+### Default
+
+Polymorphic, discriminated by `DefaultKind`, matching the `TypeName` discriminator on types:
+
+```json
+{ "DefaultKind": "NumberDefault", "value": 1.0 }
+{ "DefaultKind": "BooleanDefault", "value": true }
+{ "DefaultKind": "TextDefault", "value": "Dynamic" }
+```
+
+`NumberDefault` carries a number for any numeric or vector member; `BooleanDefault` a boolean;
+`TextDefault` a string member's contents, or the **name** of an enum value. The name rather than
+the ordinal, so that reordering an enum cannot silently change what a default means.
+
+A default is not the same as a zeroed value. `default(T)` in C# and a value-initialised struct in
+C++ are all-zero bytes, which is rarely what a schema means by "the default".
+
+### Network
+
+```json
+{ "quantise": 0.01, "delta": true }
+```
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `quantise` | number | The smallest change worth transmitting, in the member's own unit. Zero means full precision. |
+| `delta` | boolean | Whether to send the member only when it differs from the last acknowledged state. |
+
+Both are advisory: a codec that ignores them is still correct, just larger. A quantised round
+trip is accurate to half the step and no better.
 
 ## Enum
 
@@ -257,6 +331,14 @@ needs to know about.
 | --- | --- | --- |
 | *(absent)* | - | Any file written before versioning. Read as version 0 and migrated on load. |
 | `1` | The version field itself | A member's description moved from `memberDescription` to the `description` every element shares. |
+| `2` | Semantic member metadata | A member may carry `unit`, `range`, `defaultValue`, `interpolation`, `network` and `editor`. All optional and omitted when absent. |
+
+Version 2 is purely additive: a file that uses none of the new properties is byte-identical to
+the version 1 file it would have been. The version still moves, because a version 1 reader
+ignores properties it does not recognise — it would load such a file, drop the metadata, and
+write it back without it, losing information that the round-trip contract above says must
+survive. Refusing to read a version 2 file is the honest outcome, and is what the policy below
+already specifies.
 
 ### How a reader must behave
 


### PR DESCRIPTION
Three pieces of work, plus two follow-ups from the quality gate: the model and file format for the metadata a member carries beside its type, the editor surface that lets a person set it, and the generated C# that carries it out to a consumer and back.

## 1. Give a member a unit, a range, a default, and how to send it

A member could say what type it was and nothing about what it meant. This adds the semantic layer: `Unit`, `Range`, `DefaultValue`, `Interpolation`, `Network` and `Editor`, as direct properties on `SchemaMember` and on `ISchemaMember`. All six are optional and omitted when absent.

### Units come from ktsu.Semantics.Quantities

A member stores the text — a symbol (`"m/s"`) or a unit name (`"MeterPerSecond"`) — and `UnitRegistry` resolves it against the 189 units in that package, so conversion factors and dimensional formulae stay owned by the library that generates them instead of being copied into every schema file. The registry is built by reflecting over the quantities assembly rather than being a list maintained here, which would fall behind every unit added upstream.

Symbols are not unique, and the two collisions are not harmless: `g` is both gram and standard gravity, and `rad` is both radian and *radiation absorbed dose* — not even the same dimension. Resolution refuses an ambiguous symbol and names the candidates rather than picking one; writing the unit's name is how a schema escapes it.

Name lookup is `StringComparer.Ordinal`, not `OrdinalIgnoreCase`: with case-insensitivity `"rad"` matched the *name* `Rad` before the symbol check ran and silently resolved to an absorbed radiation dose instead of reporting the ambiguity.

### Validation

Checks what only makes sense in combination: a unit on something that measures nothing, a backwards range, a default outside its range or of the wrong kind, an enum default naming a value the enum does not have, interpolation on something with no meaningful midpoint, a negative quantisation step. A quantisation step wider than the whole range is a warning rather than an error — suspicious, not invalid.

`wrap` is the case that is easy to get backwards, so it is stated explicitly in the docs and asserted in the tests: a wrapping range is a *period*, not a bound. Seven radians on a `[0, 2π)` member is un-normalised rather than wrong, and clamping it to the maximum is the one transformation that is certainly incorrect. A default outside a wrapping range is therefore accepted.

### formatVersion moves to 2

Purely additive — a file using none of the new properties is byte-identical to the version 1 file it would have been — but a version 1 reader ignores properties it does not recognise, so it would load such a file, drop the metadata and write it back without it. That is exactly the information loss the round-trip contract in `docs/schema-format.md` forbids, so refusing to read it is the honest outcome.

### Three defects found by looking at the emitted JSON

A round trip passes happily on all three, so a test now asserts the emitted JSON directly.

- `IsWellFormed` and `IsQuantised` were being written to the file. A derived property in a file is a second, independently editable copy of a fact the file already states. Now `[JsonIgnore]`.
- `Interpolation` was written as an ordinal, so inserting a mode into the enum would have silently changed the meaning of every existing schema. It is written by name now.
- The docs said the default discriminator was `defaultKind`; it is `DefaultKind`, matching the existing `TypeName` discriminator.

## 2. Let the editor set a member's unit, range, default and encoding

The metadata existed in the model and in the file, and nowhere a person could reach it: the editor drew a member's name, type, container and key, and none of the six.

Each member row now has a second fold beside the description one, holding a unit picker, the range and its wrap flag, the default and its kind, the interpolation mode, the network encoding and the editor hint. Folded away rather than in the row, because the row is already five controls wide and all six are absent on most members — an identifier measures nothing and blends with nothing. The fold's own button says whether there is anything behind it, since a folded row is the only place most members are ever seen.

- **The unit picker is the registry**, searchable by name or symbol. What it writes is `UnitRegistry.PreferredText`: the symbol when the symbol names one unit, the name when it does not. A picker knows which unit was chosen, so writing `"rad"` for a radian — text the resolver then refuses as ambiguous — would throw that away. A test asserts the round trip over every unit in the registry rather than a sample.
- **An enum member's default is offered as that enum's values** rather than as free text. It is the mistake the property invites, and the schema already knows which names are allowed.
- **Numbers go through a new `EditField.Number`**, for the reason the rest of that class exists: ImGui's own numeric input reports its value every frame, so a bound edited through it would push an undo entry per keystroke. Text also holds what a number cannot (`-`, `0.`, an empty box) without the model seeing any of it, and unparsable text leaves the bound alone. Every edit here is one undo entry, and a range and an encoding are immutable, so each edit replaces one rather than mutating it.

## 3. Carry the metadata through generated C# and back

Generated code said a member was a `float` and nothing about what the float meant, so a consumer reading the generated types got none of this, and reimporting them gave back a schema missing everything it started with.

Generated properties now carry `SchemaUnit`, `SchemaRange`, `SchemaDefault`, `SchemaInterpolation`, `SchemaNetwork` and `SchemaEditorHint` from `ktsu.Schema.Runtime`, and the importer reads them back. This is what `SchemaKeyAttribute` already did for a keyed map's key member, for the same reason: a CLR type cannot say it, so without the attribute the round trip loses it. The existing generate-compile-reimport test now compares all six, so neither side can change alone.

```csharp
[ktsu.Schema.Runtime.SchemaUnit("m/s")]
[ktsu.Schema.Runtime.SchemaRange(0D, 6.2831853D, Wrap = true)]
[ktsu.Schema.Runtime.SchemaDefault(1.5D)]
[ktsu.Schema.Runtime.SchemaEditorHint("dial")]
public float Ratio { get; set; } = 1.5f;
```

`SchemaDefault` is one attribute with a constructor per kind of value rather than three attributes, because a member has one default: the overload the generator picks says which kind it is, and the boxed value is what still remembers on the way back. A default is also emitted as the property's initialiser, so a generated instance *starts* at the default instead of merely recording what it should have been — the initialiser makes the object right, the attribute makes the default readable off the type. A default of a kind the member cannot hold is a validation error and generation refuses an invalid schema, but the generator is public, so a mismatch falls through to the type's own initialiser rather than emitting source that does not compile; there is a test for that path.

## Floating point, twice, from the quality gate

The last two commits answer SonarCloud and the code-quality bot, which found three exact floating-point comparisons in the new code. Both bots proposed tolerances; none was taken, because in each case a tolerance changes what the check means.

- **Is a default a whole number.** The member is integral, so the default has to survive narrowing to an `int`; accepting `1.0000000001` as whole means accepting a value that then silently becomes `1` — the loss the check exists to catch. It reads `!double.IsInteger(number.Value)` now, which asks the question directly. One deliberate consequence: an infinite default on an integral member is now reported, because `Math.Truncate(double.PositiveInfinity)` returns the infinity and the old comparison called it whole.
- **Is a wrapping range zero-width.** `Math.Abs(min - max) <= double.Epsilon` is not a tolerance — `double.Epsilon` is the smallest denormal — it is equality that reads as though it forgives imprecision. The check now runs after the well-formed check, which lets it read `Maximum <= Minimum`: the range satisfies `min <= max` by then, so that states equality without comparing two doubles.
- **Has the number in a field changed.** The field is bound to text, so it is answered as text: render the parsed value and compare the strings. `"1.0"` and `"1"` still count as the same number.

Each has a test for the edge it decides.

## Three extractions, no behaviour change

`SchemaEditor` and `Schema` were each one type below CA1506's coupling limit, so each of these was needed to add anything at all, and each is the pattern the repository already uses (`CodeGeneratorPanel`):

- `MemberGridPanel` — the member grid, out of `SchemaEditor`.
- `MemberSemanticsPanel` — the metadata fold.
- `ClrTypeImporter` — the reflection importer, out of `Schema`. `Schema.AddClass(Type)` is unchanged and delegates to it.

No probe name changed, so the existing editor tests moved with the grid untouched.

## Testing

49 new tests. In Release on net10.0: **334 pass** in `Schema.Test` and **201 pass** in `SchemaEditor.Test`, none failing or skipped. The editor tests drive the real editor headlessly, because an immediate-mode control's value only reaches the schema through what the widget reports. `Schema` also targets net9.0 and net8.0 — both compile, and CI runs all of them on Ubuntu and Windows.

The remaining Sonar findings on the branch are assertion-style preferences from a newer MSTest analyzer (`Assert.IsEmpty` over `Assert.AreEqual(0, …)`, and so on). They are maintainability rather than reliability, the gate does not fail on them, and the rest of this suite does not follow that style either — converting only the new tests would leave the suite inconsistent with itself.

`docs/schema-format.md`, `README.md` and `CLAUDE.md` are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NmGpVzuXro25PVp3e1CRru